### PR TITLE
Ignore seal of approval scripts

### DIFF
--- a/classes/autoptimizeConfig.php
+++ b/classes/autoptimizeConfig.php
@@ -381,7 +381,7 @@ if (get_option('autoptimize_show_adv','0')=='1') {
 			$config = array('autoptimize_html' => 0,
 				'autoptimize_html_keepcomments' => 0,
 				'autoptimize_js' => 0,
-				'autoptimize_js_exclude' => "s_sid, smowtion_size, sc_project, WAU_, wau_add, comment-form-quicktags, edToolbar, ch_client, nonce, post_id",
+				'autoptimize_js_exclude' => "s_sid, smowtion_size, sc_project, WAU_, wau_add, comment-form-quicktags, edToolbar, ch_client, nonce, post_id, seal.js",
 				'autoptimize_js_trycatch' => 0,
 				'autoptimize_js_justhead' => 0,
 				'autoptimize_js_forcehead' => 0,


### PR DESCRIPTION
Several credit card, security, and ssl certificate companies provide script... to embed in a webpage to show that a site is safe to use.  anecdotally they seem to have kind of standardized on using 'seal.js' as the script name.

We don't want to do anything with these script because it generates html output to embed inline in a web page.