### PR TITLE
Remove the 'type' attribute from the script tag

### DIFF
--- a/classes/autoptimizeScripts.php
+++ b/classes/autoptimizeScripts.php
@@ -237,7 +237,7 @@ class autoptimizeScripts extends autoptimizeBase {
 		$replaceTag = apply_filters( 'autoptimize_filter_js_replacetag', $replaceTag );
 
 		$bodyreplacement = implode('',$this->move['first']);
-		$bodyreplacement .= '<script type="text/javascript" '.$defer.'src="'.$this->url.'"></script>';
+		$bodyreplacement .= '<script '.$defer.'src="'.$this->url.'"></script>';
 		$bodyreplacement .= implode('',$this->move['last']);
 
 		$this->inject_in_html($bodyreplacement,$replaceTag);


### PR DESCRIPTION
The generated script tag includes the type attribute set to text/javascript.  The type attribute is optional, browsers default to JavaScript.  From https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script - "If this attribute is absent, the script is treated as JavaScript."

Removing this saves us a few more bytes on each page laod.