### PR TITLE
Filter for changing url of generated javascript file never fires unless override is set in ui

### DIFF
--- a/classes/autoptimizeBase.php
+++ b/classes/autoptimizeBase.php
@@ -212,7 +212,6 @@ abstract class autoptimizeBase {
 			} else {
 				// get wordpress base URL
 				$WPSiteBreakdown = parse_url( AUTOPTIMIZE_WP_SITE_URL );
-				$WPSiteBreakdown = parse_url( AUTOPTIMIZE_WP_SITE_URL );
 				$WPBaseUrl       = $WPSiteBreakdown['scheme'] . '://' . $WPSiteBreakdown['host'];
 				if ( ! empty( $WPSiteBreakdown['port'] ) ) {
 					$WPBaseUrl .= ":" . $WPSiteBreakdown['port'];

--- a/classes/autoptimizeBase.php
+++ b/classes/autoptimizeBase.php
@@ -203,37 +203,35 @@ abstract class autoptimizeBase {
                 }
                 return $comments_out;
 	}
-	
-        protected function url_replace_cdn($url) {
-                if (!empty($this->cdn_url)) {
-                // first allow API filter to take care of CDN replacement
-                        $tmp_url = apply_filters( 'autoptimize_filter_base_replace_cdn',$url);
-                        if ($tmp_url === $url) {
-                                // secondly prepend domain-less absolute URL's
-                                if((substr($url,0,1)==='/')&&(substr($url,1,1)!=='/')) {
-                                	$url=rtrim($this->cdn_url,'/').$url;
-                                } else {
-                                	// get wordpress base URL
-                                	$WPSiteBreakdown = parse_url(AUTOPTIMIZE_WP_SITE_URL);										$WPSiteBreakdown = parse_url(AUTOPTIMIZE_WP_SITE_URL);
-					$WPBaseUrl = $WPSiteBreakdown['scheme'] . '://' . $WPSiteBreakdown['host'];
-					if (!empty($WPSiteBreakdown['port'])) {
-						$WPBaseUrl.=":".$WPSiteBreakdown['port'];
-					}
-                                        // three: replace full url's with scheme
-                                        $tmp_url=str_replace($WPBaseUrl,rtrim($this->cdn_url,'/'),$url);
-                                        if ($tmp_url===$url) {
-                                                // last attempt; replace scheme-less URL's
-                                                $url=str_replace(preg_replace('/https?:/','',$WPBaseUrl),rtrim($this->cdn_url,'/'),$url);
-                                        } else {
-                                                $url=$tmp_url;
-                                        }
-                                }
-                        } else {
-                                $url=$tmp_url;
-                        }
-                }
-                return $url;
-        }
+
+	protected function url_replace_cdn( $url ) {
+		if ( ! empty( $this->cdn_url ) ) {
+			// secondly prepend domain-less absolute URL's
+			if ( ( substr( $url, 0, 1 ) === '/' ) && ( substr( $url, 1, 1 ) !== '/' ) ) {
+				$url = rtrim( $this->cdn_url, '/' ) . $url;
+			} else {
+				// get wordpress base URL
+				$WPSiteBreakdown = parse_url( AUTOPTIMIZE_WP_SITE_URL );
+				$WPSiteBreakdown = parse_url( AUTOPTIMIZE_WP_SITE_URL );
+				$WPBaseUrl       = $WPSiteBreakdown['scheme'] . '://' . $WPSiteBreakdown['host'];
+				if ( ! empty( $WPSiteBreakdown['port'] ) ) {
+					$WPBaseUrl .= ":" . $WPSiteBreakdown['port'];
+				}
+				// three: replace full url's with scheme
+				$tmp_url = str_replace( $WPBaseUrl, rtrim( $this->cdn_url, '/' ), $url );
+				if ( $tmp_url === $url ) {
+					// last attempt; replace scheme-less URL's
+					$url = str_replace( preg_replace( '/https?:/', '', $WPBaseUrl ), rtrim( $this->cdn_url, '/' ), $url );
+				} else {
+					$url = $tmp_url;
+				}
+			}
+		}
+
+		// allow API filter to take care of CDN replacement
+		$url = apply_filters( 'autoptimize_filter_base_replace_cdn', $url );
+		return $url;
+	}
 
 	protected function inject_in_html($payload,$replaceTag) {
 		if (strpos($this->content,$replaceTag[0])!== false) {


### PR DESCRIPTION
enable filtering of js url even if the admin ui does not have an override set for cdn url, filter happens after other processing for url