### PR TITLE
Updates 'inline and defer CSS' option to be compatible with Cloudflare Rocket Loader

### DIFF
--- a/classes/autoptimizeStyles.php
+++ b/classes/autoptimizeStyles.php
@@ -513,7 +513,7 @@ LOD;
 			}
 		} else {
 			if ($this->defer == true) {
-				$deferredCssBlock = "<script>function lCss(url,media) {var d=document;var l=d.createElement('link');l.rel='stylesheet';l.type='text/css';l.href=url;l.media=media;aoin=d.getElementsByTagName('noscript')[0];aoin.parentNode.insertBefore(l,aoin.nextSibling);}function deferredCSS() {";
+				$deferredCssBlock = "<script data-cfasync='false'>function lCss(url,media) {var d=document;var l=d.createElement('link');l.rel='stylesheet';l.type='text/css';l.href=url;l.media=media;aoin=d.getElementsByTagName('noscript')[0];aoin.parentNode.insertBefore(l,aoin.nextSibling);}function deferredCSS() {";
 				$noScriptCssBlock = "<noscript>";
 				$defer_inline_code=$this->defer_inline;
 				$defer_inline_code=apply_filters( 'autoptimize_filter_css_defer_inline', $defer_inline_code );


### PR DESCRIPTION
Hello, while trying 'inline and defer CSS', I found that the inline CSS is working, but the full CSS is not being deffered correctly (it's not even loading..). So, while trying to understand the bug, I remember myself that I have CloudFlare's Rocket Loader enabled and..for wtf reasons, I found that Cloudflare is trying to 'Rocketize' the inline script that loads the CSS after the page is loaded. But..there's no script to load asynchronously, or the script is not compatible with Rocket Loader...well, I don't know, but anyway, because the inline script is so small, I just added a data tag to remember CloudFlare to not modify the inline script, and so the CSS loads and we will be all happy. \o/

If you want, you can find the working example in my website, here: http://fjorgemota.com - Note that it have Rocket Loader enabled. :)