### PR TITLE
Avoid false positives when searching for background-* properties

### DIFF
--- a/classes/autoptimizeStyles.php
+++ b/classes/autoptimizeStyles.php
@@ -296,7 +296,7 @@ class autoptimizeStyles extends autoptimizeBase {
 
 			// Do the imaging!
 			$imgreplace = array();
-			preg_match_all('#(background[^;}]*url\((?!\s?"?\s?data)(.*)\)[^;}]*)(?:;|$|})#Usm',$code,$matches);
+			preg_match_all('#(background[^;{}]*url\((?!\s?"?\s?data)(.*)\)[^;}]*)(?:;|$|})#Usm',$code,$matches);
 			
 			if(($this->datauris == true) && (function_exists('base64_encode')) && (is_array($matches)))	{
 				foreach($matches[2] as $count => $quotedurl) {


### PR DESCRIPTION
A regex like #background[^;}]*url# will match, in addition to
background or background-image property declarations, any ruleset
for a class or ID containing the word "background". Adding an opening
brace to the negated character class in the regex fixes this.

fixes #42