### PR TITLE
change ext .gzip to .gz

### DIFF
--- a/classes/autoptimizeCache.php
+++ b/classes/autoptimizeCache.php
@@ -59,7 +59,7 @@ class autoptimizeCache {
             file_put_contents($this->cachedir.$this->filename,$code, LOCK_EX);
             if (apply_filters('autoptimize_filter_cache_create_static_gzip', false)) {
                 // Create an additional cached gzip file
-                file_put_contents($this->cachedir.$this->filename.'.gzip',gzencode($code,9,FORCE_GZIP), LOCK_EX);
+                file_put_contents($this->cachedir.$this->filename.'.gz', gzencode($code,9,FORCE_GZIP), LOCK_EX);
             }
         }
     }


### PR DESCRIPTION
About https://github.com/futtta/autoptimize/issues/59
Practice shows that most often use .gz extension to compressed files with gzip
Nginx, module ngx_http_gzip_static_module uses only .gz extension.