### PR TITLE
Make autoptimize_filter_js_unmovable work in aggregating the inline styles

### DIFF
--- a/classes/autoptimizeScripts.php
+++ b/classes/autoptimizeScripts.php
@@ -345,8 +345,8 @@ class autoptimizeScripts extends autoptimizeBase {
     
     // Checks againstt the blacklist
     private function ismovable($tag) {
-        if ($this->include_inline !== true || apply_filters('autoptimize_filter_js_unmovable',true)) {
-            return false;
+        if ($this->include_inline !== true) {
+            return apply_filters('autoptimize_filter_js_unmovable',false);
         }
         
         foreach($this->domove as $match) {


### PR DESCRIPTION
Based on the following: “Re-enable functionality to move non-aggregated JS if “also aggregate inline JS” is active (can be disabled with autoptimize_filter_js_unmovable filter)” i've read [here](https://wordpress.org/support/topic/201-is-out-some-issues/), I've tried it out and it didn't work.
As I dived into the code the logic seemed a bit off for this filter... or maybe it's not named properly to make perfect sense. 

I wasn’t able by using the filter to aggregate the inline JS (which was non-aggregated as per my option) at the bottom of the body without moving this filter in the return statement instead. 
I tried to add the filter with either true or false, and it never aggregated the scripts which were sprinkled all over the mark-up.

This is how I thought of it
`if ($this->include_inline !== true) {`
-> if we don't want to include the inline scripts in the aggregated big file
... I want to override the default (of not moving the inline js) in the theme -> to leave them inline, but move them together at the end by overriding this filter:
`return apply_filters('autoptimize_filter_js_unmovable',false);`

Ideally I'd like to accomplish this at the end of the body element:
- the combined JS file
- the aggregated inline scripts which depend on bits inside the combined JS file

And this way there would be no requirement to put the combined JS file in the head (and block rendering on some browsers) OR create many many cacheable resources for most pages once you have a dynamic back-end variable added to an inline script... which both represent less ideal circumstances.