### PR TITLE
Strings correction to improve localization

### DIFF
--- a/autoptimize.php
+++ b/autoptimize.php
@@ -112,12 +112,7 @@ function autoptimize_update_config_notice() {
 
 function autoptimize_cache_unavailable_notice() {
     echo '<div class="error"><p>';
-    _e(
-        'Autoptimize cannot write to the cache directory ('
-        . AUTOPTIMIZE_CACHE_DIR
-        . '), please fix to enable CSS/ JS optimization!',
-        'autoptimize'
-    );
+    printf( __( 'Autoptimize cannot write to the cache directory (%s), please fix to enable CSS/ JS optimization!', 'autoptimize' ), AUTOPTIMIZE_CACHE_DIR );
     echo '</p></div>';
 }
 

--- a/classes/autoptimizeConfig.php
+++ b/classes/autoptimizeConfig.php
@@ -151,7 +151,7 @@ input[type=url]:invalid {color: red; border-color:red;} .form-table th{font-weig
 <div class="wrap">
 
 <?php if (version_compare(PHP_VERSION, '5.3.0') < 0) { ?>
-<div class="notice-error notice"><?php _e('<p><strong>You are using a very old version of PHP</strong> (5.2.x or older) which has <a href="http://blog.futtta.be/2016/03/15/why-would-you-still-be-on-php-5-2/" target="_blank">serious security and performance issues</a>. Please ask your hoster to provide you with an upgrade path to 5.6 or 7.0</p>','autoptimize'); ?></div>
+<div class="notice-error notice"><?php echo '<p>' . sprintf( __('<strong>You are using a very old version of PHP</strong> (5.2.x or older) which has <a href=%s>serious security and performance issues</a>. Please ask your hoster to provide you with an upgrade path to 5.6 or 7.0.','autoptimize'), '"http://blog.futtta.be/2016/03/15/why-would-you-still-be-on-php-5-2/" target="_blank"') . '</p>'; ?></div>
 <?php } ?>
 
 <div id="autoptimize_main">
@@ -214,7 +214,7 @@ input[type=url]:invalid {color: red; border-color:red;} .form-table th{font-weig
 </tr>
 <?php if (get_option('autoptimize_js_justhead')) { ?>
 <tr valign="top" class="<?php echo $hiddenClass;?>js_sub ao_adv">
-<th scope="row"><?php _e('Look for scripts only in &lt;head&gt;?','autoptimize');  _e(' <i>(deprecated)</i>','autoptimize'); ?></th>
+<th scope="row"><?php _e('Look for scripts only in &lt;head&gt;?','autoptimize'); echo ' <i>'. __('(deprecated)','autoptimize') . '</i>'; ?></th>
 <td><label class="cb_label"><input type="checkbox" name="autoptimize_js_justhead" <?php echo get_option('autoptimize_js_justhead')?'checked="checked" ':''; ?>/>
 <?php _e('Mostly useful in combination with previous option when using jQuery-based templates, but might help keeping cache size under control.','autoptimize'); ?></label></td>
 </tr>
@@ -256,7 +256,7 @@ input[type=url]:invalid {color: red; border-color:red;} .form-table th{font-weig
 </tr>
 <?php if (get_option('autoptimize_css_justhead')) { ?>
 <tr valign="top" class="<?php echo $hiddenClass;?>css_sub ao_adv">
-<th scope="row"><?php _e('Look for styles only in &lt;head&gt;?','autoptimize'); _e(' <i>(deprecated)</i>','autoptimize'); ?></th>
+<th scope="row"><?php _e('Look for styles only in &lt;head&gt;?','autoptimize'); echo ' <i>'. __('(deprecated)','autoptimize') . '</i>'; ?></th>
 <td><label class="cb_label"><input type="checkbox" name="autoptimize_css_justhead" <?php echo get_option('autoptimize_css_justhead')?'checked="checked" ':''; ?>/>
 <?php _e('Don\'t autoptimize CSS outside the head-section. If the cache gets big, you might want to enable this.','autoptimize'); ?></label></td>
 </tr>
@@ -315,7 +315,7 @@ input[type=url]:invalid {color: red; border-color:red;} .form-table th{font-weig
 <td><?php
     $AOstatArr=autoptimizeCache::stats(); 
     $AOcacheSize=round($AOstatArr[1]/1024);
-    echo $AOstatArr[0].__(' files, totalling ','autoptimize').$AOcacheSize.__(' Kbytes (calculated at ','autoptimize').date("H:i e", $AOstatArr[2]).')';
+    printf( __( '%1$s files, totalling %2$s Kbytes (calculated at %3$s)', 'autoptimize'), $AOstatArr[0], $AOcacheSize, date("H:i e", $AOstatArr[2]) );
 ?></td>
 </tr>
 <tr valign="top" class="<?php echo $hiddenClass;?>ao_adv">

--- a/classes/autoptimizeToolbar.php
+++ b/classes/autoptimizeToolbar.php
@@ -121,7 +121,7 @@ class autoptimizeToolbar {
         // Localizes a registered script with data for a JavaScript variable. (We need this for the AJAX work properly in the front-end mode)
         wp_localize_script( 'autoptimize-toolbar', 'autoptimize_ajax_object', array(
             'ajaxurl' => admin_url( 'admin-ajax.php' ),
-            'error_msg' => __( 'Your Autoptimize cache might not have been purged successfully, please check on the <a href=' . admin_url( 'options-general.php?page=autoptimize' ) . '  style="white-space:nowrap;">Autoptimize settings page</a>.', 'autoptimize' ),
+            'error_msg' => sprintf( __( 'Your Autoptimize cache might not have been purged successfully, please check on the <a href=%s>Autoptimize settings page</a>.', 'autoptimize' ), admin_url( 'options-general.php?page=autoptimize' ) . ' style="white-space:nowrap;"' ),
             'dismiss_msg' => __( 'Dismiss this notice.' ),
             'nonce' => wp_create_nonce( 'ao_delcache_nonce' )
         ) );

--- a/classlesses/autoptimizePartners.php
+++ b/classlesses/autoptimizePartners.php
@@ -72,7 +72,7 @@ function ao_partners() {
         <h1><?php _e('Autoptimize Settings','autoptimize'); ?></h1>
         <?php echo autoptimizeConfig::ao_admin_tabs(); ?>
         <?php
-            _e("<h2>These Autoptimize power-ups and related services will improve your site's performance even more!</h2>","autoptimize");
+            echo '<h2>'. __("These Autoptimize power-ups and related services will improve your site's performance even more!",'autoptimize') . '</h2>';
         ?>
         <div>
             <?php getAOPartnerFeed(); ?>


### PR DESCRIPTION
As commented in https://github.com/futtta/autoptimize/commit/41bc7e3498a5277d9f3957a51317753affbb6453, I've created this pull request with the following changes:

- Concatenate strings to allow gettext function to grab it completely
- Concatenate strings to allow better context understanding for translators
- Removed unnecessary HTML strings (e.g. `<p>` and `<h2>`) from the beginning and ending of strings
- Revomed *some* href URLs to avoid any error from translator -> made this in just a few as example, there are many more where it could be done