### PR TITLE
Override max-age directive from WP SuperCache

### DIFF
--- a/classes/autoptimizeCache.php
+++ b/classes/autoptimizeCache.php
@@ -193,7 +193,7 @@ class autoptimizeCache {
         ExpiresByType application/javascript A30672000
 </IfModule>
 <IfModule mod_headers.c>
-    Header append Cache-Control "public, immutable"
+    Header set Cache-Control "public, immutable"
 </IfModule>
 <IfModule mod_deflate.c>
         <FilesMatch "\.(js|css)$">


### PR DESCRIPTION
In a recent change, Autoptimizer has stopped overriding WP SuperCache's max-age directive. My guess is that was unintended, but of course I'm not sure what lead to this change. 

In [this commit](https://github.com/futtta/autoptimize/commit/aa76f54ad8ae8e88f17e4015584e5b942be3bd9d) the `Header set Cache-Control` that set the max-age to a lengthier timeframe was removed (seemingly in favour of the ExpiresByTime), then in [another commit](https://github.com/futtta/autoptimize/commit/062450363defab417dcbe4890a6418ca5360a265) a `Header append Cache-Control` was added without the max-age directive. This means that now WP SuperCache's max-age – which is set quite liberally – is now affecting Autoptimize's combined CSS files.

Since we're later setting `Expires` anyway, changing this to `Header set Cache-Control "public, immutable"` would remove WP SuperCache's max-age and let the `Expires` headers take over. 

I'm not sure if there's more to the initial changes than I'm able to see at the moment, so feel free to shut this down if that's the case.