### PR TITLE
WP_ROOT_DIR replace too greedy

### DIFF
--- a/autoptimize.php
+++ b/autoptimize.php
@@ -46,7 +46,7 @@ if (is_multisite() && apply_filters( 'autoptimize_separate_blog_caches' , true )
     define('AUTOPTIMIZE_CACHE_DIR', WP_CONTENT_DIR.AUTOPTIMIZE_CACHE_CHILD_DIR);
 }
 define('AUTOPTIMIZE_CACHE_DELAY',true);
-define('WP_ROOT_DIR',str_replace(AUTOPTIMIZE_WP_CONTENT_NAME,'',WP_CONTENT_DIR));
+define('WP_ROOT_DIR',substr(WP_CONTENT_DIR, 0, strlen(WP_CONTENT_DIR)-strlen(AUTOPTIMIZE_WP_CONTENT_NAME)));
 
 // Initialize the cache at least once
 $conf = autoptimizeConfig::instance();


### PR DESCRIPTION
Changed str_replace to substr to only remove the AUTOTIMIZE_WP_CONTENT_NAME from the end of WP_CONTENT_DIR, instead of in the entire string.