### PR TITLE
WP CLI support

### DIFF
--- a/autoptimize.php
+++ b/autoptimize.php
@@ -48,6 +48,11 @@ if (is_multisite() && apply_filters( 'autoptimize_separate_blog_caches' , true )
 define('AUTOPTIMIZE_CACHE_DELAY',true);
 define('WP_ROOT_DIR',substr(WP_CONTENT_DIR, 0, strlen(WP_CONTENT_DIR)-strlen(AUTOPTIMIZE_WP_CONTENT_NAME)));
 
+// WP CLI
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	require_once AUTOPTIMIZE_PLUGIN_DIR . 'classes/autoptimizeCLI.php';
+}
+
 // Initialize the cache at least once
 $conf = autoptimizeConfig::instance();
 

--- a/classes/autoptimizeCLI.php
+++ b/classes/autoptimizeCLI.php
@@ -34,7 +34,7 @@ class autoptimizeCLI extends WP_CLI_Command {
 		global $wp_filesystem;
 		$wp_filesystem->rmdir( AUTOPTIMIZE_CACHE_DIR . $clear, true );
 
-		WP_CLI::success( esc_html__( sprintf( '%s cache cleared.', strtoupper( $clear ) ),'autoptimize' ) );
+		WP_CLI::success( esc_html__( sprintf( '%s cache cleared.', strtoupper( $clear ) ), 'autoptimize' ) );
 	}
 
 }

--- a/classes/autoptimizeCLI.php
+++ b/classes/autoptimizeCLI.php
@@ -1,0 +1,42 @@
+<?php
+// Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class autoptimizeCLI extends WP_CLI_Command {
+
+	/**
+	 * Clears the cache.
+	 *
+	 * @subcommand clear
+	 * @synopsis [--type=<css|js>]
+	 */
+	public function clear( $args, $args_assoc ) {
+		$clear = '';
+		if ( ! empty( $args_assoc ) ) {
+			$clear = $args_assoc['type'];
+			if ( ! in_array( $clear, array( 'css', 'js' ), true ) ) {
+				WP_CLI::error( esc_html__( 'Please choose `css` or `js`.', 'autoptimize' ) );
+			}
+		}
+
+		if ( empty( $clear ) ) {
+			WP_CLI::line( esc_html__( 'Flushing the cache...', 'autoptimize' ) );
+			autoptimizeCache::clearall();
+			WP_CLI::success( esc_html__( 'Cache flushed.', 'autoptimize' ) );
+			return;
+		}
+
+		WP_CLI::line( esc_html__( 'Clearing the cache...', 'autoptimize' ) );
+
+		WP_Filesystem();
+		global $wp_filesystem;
+		$wp_filesystem->rmdir( AUTOPTIMIZE_CACHE_DIR . $clear, true );
+
+		WP_CLI::success( esc_html__( sprintf( '%s cache cleared.', strtoupper( $clear ) ),'autoptimize' ) );
+	}
+
+}
+
+WP_CLI::add_command( 'autoptimize', 'autoptimizeCLI' );

--- a/classes/autoptimizeCLI.php
+++ b/classes/autoptimizeCLI.php
@@ -10,31 +10,11 @@ class autoptimizeCLI extends WP_CLI_Command {
 	 * Clears the cache.
 	 *
 	 * @subcommand clear
-	 * @synopsis [--type=<css|js>]
 	 */
 	public function clear( $args, $args_assoc ) {
-		$clear = '';
-		if ( ! empty( $args_assoc ) ) {
-			$clear = $args_assoc['type'];
-			if ( ! in_array( $clear, array( 'css', 'js' ), true ) ) {
-				WP_CLI::error( esc_html__( 'Please choose `css` or `js`.', 'autoptimize' ) );
-			}
-		}
-
-		if ( empty( $clear ) ) {
-			WP_CLI::line( esc_html__( 'Flushing the cache...', 'autoptimize' ) );
-			autoptimizeCache::clearall();
-			WP_CLI::success( esc_html__( 'Cache flushed.', 'autoptimize' ) );
-			return;
-		}
-
-		WP_CLI::line( esc_html__( 'Clearing the cache...', 'autoptimize' ) );
-
-		WP_Filesystem();
-		global $wp_filesystem;
-		$wp_filesystem->rmdir( AUTOPTIMIZE_CACHE_DIR . $clear, true );
-
-		WP_CLI::success( esc_html__( sprintf( '%s cache cleared.', strtoupper( $clear ) ), 'autoptimize' ) );
+		WP_CLI::line( esc_html__( 'Flushing the cache...', 'autoptimize' ) );
+		autoptimizeCache::clearall();
+		WP_CLI::success( esc_html__( 'Cache flushed.', 'autoptimize' ) );
 	}
 
 }


### PR DESCRIPTION
This fixes: https://github.com/futtta/autoptimize/issues/116

Adds a new WP CLI command to clear the cache with the following options:

`wp autoptimize clear` flushes the cache (clears and re-builds)
`wp autoptimize clear --type=css` clears the CSS cache
`wp autoptimize clear --type=js` clears the JS cache