### PR TITLE
Exclude `noindex` comment tag

### DIFF
--- a/classes/autoptimizeHTML.php
+++ b/classes/autoptimizeHTML.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 class autoptimizeHTML extends autoptimizeBase {
     private $keepcomments = false;
-    private $exclude = array('<!-- ngg_resource_manager_marker -->');
+    private $exclude = array('<!-- ngg_resource_manager_marker -->', '<!--noindex-->', '<!--/noindex-->');
     
     public function read($options) {
         // Remove the HTML comments?


### PR DESCRIPTION
This comment tag is used by Yandex to prevent indexing non-content parts of a page.
See https://yandex.com/support/webmaster/controlling-robot/html.html#noindex