### PR TITLE
change html-minify behavior wrt html comments inside script blocks

### DIFF
--- a/classes/external/php/minify-html.php
+++ b/classes/external/php/minify-html.php
@@ -236,13 +236,13 @@ class Minify_HTML {
         $ws1 = ($m[1] === '') ? '' : ' ';
         $ws2 = ($m[4] === '') ? '' : ' ';
 
-        if ($this->_keepComments == false) {
-            // remove HTML comments (and ending "//" if present)
+        // remove HTML comments (and ending "//" if present)
+        if (!$this->_keepComments) {
             $js = preg_replace('/(?:^\\s*<!--\\s*|\\s*(?:\\/\\/)?\\s*-->\\s*$)/', '', $js);
-
-            // remove CDATA section markers
-            $js = $this->_removeCdata($js);
         }
+
+        // remove CDATA section markers
+        $js = $this->_removeCdata($js);
 
         // minify
         $minifier = $this->_jsMinifier

--- a/tests/test-ao.php
+++ b/tests/test-ao.php
@@ -1681,4 +1681,150 @@ HTML;
         $this->assertContains( $styles->cdn_url, $contents );
         $this->assertContains( '.bg{background:url(' . $styles->cdn_url, $contents );
     }
+
+    public function  test_html_minify_keep_html_comments_inside_script_blocks()
+    {
+        $markup = <<<MARKUP
+<script>
+<!-- End Support AJAX add to cart -->
+var a = "b";
+</script>
+MARKUP;
+        $expected = <<<MARKUP
+<script><!-- End Support AJAX add to cart -->
+var a = "b";</script>
+MARKUP;
+
+        $markup2 = <<<MARKUP
+<script>
+var a = "b";
+<!-- End Support AJAX add to cart -->
+</script>
+MARKUP;
+
+        $expected2 = <<<MARKUP
+<script>var a = "b";
+<!-- End Support AJAX add to cart --></script>
+MARKUP;
+
+        // When keepcomments is true
+        $options = [
+            'autoptimizeHTML' => [
+                'keepcomments' => true
+            ],
+        ];
+
+        $instance = new autoptimizeHTML( $markup );
+        $instance->read( $options['autoptimizeHTML'] );
+        $instance->minify();
+        $actual = $instance->getcontent();
+        $this->assertEquals( $expected, $actual );
+
+        $instance = new autoptimizeHTML( $markup2 );
+        $instance->read( $options['autoptimizeHTML'] );
+        $instance->minify();
+        $actual2 = $instance->getcontent();
+        $this->assertEquals( $expected2, $actual2 );
+    }
+
+    public function test_html_minify_remove_html_comments_inside_script_blocks()
+    {
+        // Default case, where html comments are removed (keepcomments = false)
+        $markup1 = <<<MARKUP
+<script>
+var a = "b";
+<!-- End Support AJAX add to cart -->
+</script>
+MARKUP;
+        $expected1 = <<<MARKUP
+<script>var a = "b";
+<!-- End Support AJAX add to cart</script>
+MARKUP;
+
+        $markup2 = <<<MARKUP
+<script>
+<!-- End Support AJAX add to cart -->
+var a = "b";
+</script>
+MARKUP;
+        $expected2 = <<<MARKUP
+<script>End Support AJAX add to cart -->
+var a = "b";</script>
+MARKUP;
+
+        $options = [
+            'autoptimizeHTML' => [
+                'keepcomments' => false,
+            ],
+        ];
+
+        $instance = new autoptimizeHTML( $markup1 );
+        $instance->read( $options['autoptimizeHTML'] );
+        $instance->minify();
+        $actual = $instance->getcontent();
+        $this->assertEquals( $expected1, $actual );
+
+        $instance = new autoptimizeHTML( $markup2 );
+        $instance->read( $options['autoptimizeHTML'] );
+        $instance->minify();
+        $actual2 = $instance->getcontent();
+        $this->assertEquals( $expected2, $actual2 );
+    }
+
+    public function test_html_minify_html_comments_inside_script_blocks_old_school_pattern()
+    {
+        $markup = <<<MARKUP
+<script>
+<!-- // invisible for old browsers
+var a = "z";
+// -->
+</script>
+MARKUP;
+
+        $expected = <<<MARKUP
+<script>// invisible for old browsers
+var a = "z";</script>
+MARKUP;
+
+        $options = [
+            'autoptimizeHTML' => [
+                'keepcomments' => false,
+            ],
+        ];
+
+        $instance = new autoptimizeHTML( $markup );
+        $instance->read( $options['autoptimizeHTML'] );
+        $instance->minify();
+        $actual = $instance->getcontent();
+        $this->assertEquals( $expected, $actual );
+    }
+
+    public function test_html_minify_html_comments_inside_script_blocks_old_school_pattern_untouched()
+    {
+        $markup = <<<MARKUP
+<script>
+<!-- // invisible for old browsers
+var a = "z";
+// -->
+</script>
+MARKUP;
+
+        $expected = <<<MARKUP
+<script><!-- // invisible for old browsers
+var a = "z";
+// --></script>
+MARKUP;
+
+        $options = [
+            'autoptimizeHTML' => [
+                'keepcomments' => true,
+            ],
+        ];
+
+        $instance = new autoptimizeHTML( $markup );
+        $instance->read( $options['autoptimizeHTML'] );
+        $instance->minify();
+        $actual = $instance->getcontent();
+        $this->assertEquals( $expected, $actual );
+    }
 }


### PR DESCRIPTION
* it now obeys the "keepcomments" flag/option
* add some tests demonstrating current (sometimes broken, depending on pov) and new behavior

This allows those who have issues with html-comments-inside-script-blocks-removal to turn it off (whereas they previously couldn't influence that).

Also changes back the way cdata blocks are treated (removed regardless of keepcomments option, as was the case earlier)