### PR TITLE
multibyte-capable substr_replace() in autoptimizeBase::inject_in_html()

### DIFF
--- a/classes/autoptimizeBase.php
+++ b/classes/autoptimizeBase.php
@@ -336,8 +336,9 @@ abstract class autoptimizeBase
      */
     protected function inject_in_html( $payload, $where )
     {
-        $warned = false;
-        if ( false !== strpos( $this->content, $where[0] ) ) {
+        $warned   = false;
+        $position = autoptimizeUtils::strpos( $this->content, $where[0] );
+        if ( false !== $position ) {
             // Found the tag, setup content/injection as specified.
             if ( 'after' === $where[1] ) {
                 $content = $where[0] . $payload;
@@ -347,10 +348,12 @@ abstract class autoptimizeBase
                 $content = $payload . $where[0];
             }
             // Place where specified.
-            $this->content = substr_replace(
+            $this->content = autoptimizeUtils::substr_replace(
                 $this->content,
                 $content,
-                strpos( $this->content, $where[0] ),
+                $position,
+                // Using plain strlen() should be safe here for now, since
+                // we're not searching for multibyte chars here still...
                 strlen( $where[0] )
             );
         } else {
@@ -635,7 +638,7 @@ abstract class autoptimizeBase
     }
 
     /**
-     * checks if a single local css/js file can be minified and returns source if so.
+     * Checks if a single local css/js file can be minified and returns source if so.
      *
      * @param string $filepath Filepath.
      *
@@ -675,7 +678,7 @@ abstract class autoptimizeBase
      * Given an autoptimizeCache instance returns the (maybe cdn-ed) url of
      * the cached file.
      *
-     * @param autoptimizeCache $cache autoptimizeCache instance
+     * @param autoptimizeCache $cache autoptimizeCache instance.
      *
      * @return string
      */

--- a/classes/autoptimizeScripts.php
+++ b/classes/autoptimizeScripts.php
@@ -394,26 +394,26 @@ class autoptimizeScripts extends autoptimizeBase
         $bodyreplacementpayload = '<script type="text/javascript" ' . $defer . 'src="' . $this->url . '"></script>';
         $bodyreplacementpayload = apply_filters( 'autoptimize_filter_js_bodyreplacementpayload', $bodyreplacementpayload );
 
-        $bodyreplacement = implode( '',$this->move['first'] );
+        $bodyreplacement = implode( '', $this->move['first'] );
         $bodyreplacement .= $bodyreplacementpayload;
         $bodyreplacement .= implode( '', $this->move['last'] );
 
         $replaceTag = apply_filters( 'autoptimize_filter_js_replacetag', $replaceTag );
 
         if ( strlen( $this->jscode ) > 0 ) {
-            $this->inject_in_html($bodyreplacement, $replaceTag);
+            $this->inject_in_html( $bodyreplacement, $replaceTag );
         }
 
-        // restore comments
-        $this->content = $this->restore_comments($this->content);
+        // Restore comments.
+        $this->content = $this->restore_comments( $this->content );
 
-        // Restore IE hacks
-        $this->content = $this->restore_iehacks($this->content);
+        // Restore IE hacks.
+        $this->content = $this->restore_iehacks( $this->content );
 
-        // Restore noptimize
-        $this->content = $this->restore_noptimize($this->content);
+        // Restore noptimize.
+        $this->content = $this->restore_noptimize( $this->content );
 
-        // Return the modified HTML
+        // Return the modified HTML.
         return $this->content;
     }
 

--- a/classes/autoptimizeUtils.php
+++ b/classes/autoptimizeUtils.php
@@ -201,12 +201,12 @@ class autoptimizeUtils
         if ( null === $length ) {
             $length = 2147483647;
         } elseif ( $length < 0 ) {
-            $length = \iconv_strlen( $s, $encoding ) + $length - $start;
+            $length = self::strlen( $s, $encoding ) + ( $length - $start );
             if ( $length < 0 ) {
                 return '';
             }
         }
 
-        return (string) \iconv_substr( $s, $start, $length, $encoding );
+        return (string) ( null === $encoding ) ? \iconv_substr( $s, $start, $length ) : \iconv_substr( $s, $start, $length, $encoding );
     }
 }

--- a/classes/autoptimizeUtils.php
+++ b/classes/autoptimizeUtils.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * General helpers.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class autoptimizeUtils
+{
+    /**
+     * Returns true when mbstring is available.
+     *
+     * @param bool|null $override Allows overriding the decision.
+     *
+     * @return bool
+     */
+    public static function mbstring_available( $override = null )
+    {
+        static $available = null;
+
+        if ( null === $available ) {
+            $available = \extension_loaded( 'mbstring' );
+        }
+
+        if ( null !== $override ) {
+            $available = $override;
+        }
+
+        return $available;
+    }
+
+    /**
+     * Returns true when iconv is available.
+     *
+     * @param bool|null $override Allows overriding the decision.
+     *
+     * @return bool
+     */
+    public static function iconv_available( $override = null )
+    {
+        static $available = null;
+
+        if ( null === $available ) {
+            $available = \extension_loaded( 'iconv' );
+        }
+
+        if ( null !== $override ) {
+            $available = $override;
+        }
+
+        return $available;
+    }
+
+    /**
+     * Multibyte-capable strpos() if support is available on the server.
+     * If not, it falls back to using \strpos().
+     *
+     * @param string      $haystack Haystack.
+     * @param string      $needle   Needle.
+     * @param int         $offset   Offset.
+     * @param string|null $encoding Encoding. Default null.
+     *
+     * @return int|false
+     */
+    public static function strpos( $haystack, $needle, $offset = 0, $encoding = null )
+    {
+        if ( self::mbstring_available() ) {
+            return ( null === $encoding ) ? \mb_strpos( $haystack, $needle, $offset ) : \mb_strlen( $haystack, $needle, $offset, $encoding );
+        } elseif ( self::iconv_available() ) {
+            return ( null === $encoding ) ? \iconv_strpos( $haystack, $needle, $offset ) : \iconv_strpos( $haystack, $needle, $offset, $encoding );
+        } else {
+            return \strpos( $haystack, $needle, $offset );
+        }
+    }
+
+    /**
+     * Attempts to return the number of characters in the given $string if
+     * mbstring or iconv is available. Returns the number of bytes
+     * (instead of characters) as fallback.
+     *
+     * @param string      $string   String.
+     * @param string|null $encoding Encoding.
+     *
+     * @return int Number of charcters or bytes in given $string
+     *             (characters if/when supported, bytes otherwise).
+     */
+    public static function strlen( $string, $encoding = null )
+    {
+        if ( self::mbstring_available() ) {
+            return ( null === $encoding ) ? \mb_strlen( $string ) : \mb_strlen( $string, $encoding );
+        } elseif ( self::iconv_available() ) {
+            return ( null === $encoding ) ? @iconv_strlen( $string ) : @iconv_strlen( $string, $encoding );
+        } else {
+            return \strlen( $string );
+        }
+    }
+
+    /**
+     * Our wrapper around implementations of \substr_replace()
+     * that attempts to not break things horribly if at all possible.
+     * Uses mbstring and/or iconv if available, before falling back to regular
+     * substr_replace() (which works just fine in the majority of cases).
+     *
+     * @param string      $string      String.
+     * @param string      $replacement Replacement.
+     * @param int         $start       Start offset.
+     * @param int|null    $length      Length.
+     * @param string|null $encoding    Encoding.
+     *
+     * @return string
+     */
+    public static function substr_replace( $string, $replacement, $start, $length = null, $encoding = null )
+    {
+        if ( self::mbstring_available() ) {
+            $strlen = self::strlen( $string, $encoding );
+
+            if ( $start < 0 ) {
+                if ( -$start < $strlen ) {
+                    $start = $strlen + $start;
+                } else {
+                    $start = 0;
+                }
+            } elseif ( $start > $strlen ) {
+                $start = $strlen;
+            }
+
+            if ( null === $length || '' === $length ) {
+                $start2 = $strlen;
+            } elseif ( $length < 0 ) {
+                $start2 = $strlen + $length;
+                if ( $start2 < $start ) {
+                    $start2 = $start;
+                }
+            } else {
+                $start2 = $start + $length;
+            }
+
+            if ( null === $encoding ) {
+                $leader  = $start ? \mb_substr( $string, 0, $start ) : '';
+                $trailer = ( $start2 < $strlen ) ? \mb_substr( $string, $start2, null ) : '';
+            } else {
+                $leader  = $start ? \mb_substr( $string, 0, $start, $encoding ) : '';
+                $trailer = ( $start2 < $strlen ) ? \mb_substr( $string, $start2, null, $encoding ) : '';
+            }
+
+            return "{$leader}{$replacement}{$trailer}";
+        } elseif ( self::iconv_available() ) {
+            $strlen = self::strlen( $string, $encoding );
+
+            if ( $start < 0 ) {
+                $start = \max( 0, $strlen + $start );
+                $start = $strlen + $start;
+                if ( $start < 0 ) {
+                    $start = 0;
+                }
+            } elseif ( $start > $strlen ) {
+                $start = $strlen;
+            }
+
+            if ( $length < 0 ) {
+                $length = \max( 0, $strlen - $start + $length );
+            } elseif ( null === $length || ( $length > $strlen ) ) {
+                $length = $strlen;
+            }
+
+            if ( ( $start + $length ) > $strlen ) {
+                $length = $strlen - $start;
+            }
+
+            if ( null === $encoding ) {
+                return self::iconv_substr( $string, 0, $start ) . $replacement . self::iconv_substr( $string, $start + $length, $strlen - $start - $length );
+            }
+
+            return self::iconv_substr( $string, 0, $start, $encoding ) . $replacement . self::iconv_substr( $string, $start + $length, $strlen - $start - $length, $encoding );
+        }
+
+        return ( null === $length ) ? \substr_replace( $string, $replacement, $start ) : \substr_replace( $string, $replacement, $start, $length );
+    }
+
+    /**
+     * Wrapper around iconv_substr().
+     *
+     * @param string      $s        String.
+     * @param int         $start    Start offset.
+     * @param int|null    $length   Length.
+     * @param string|null $encoding Encoding.
+     *
+     * @return string
+     */
+    protected static function iconv_substr( $s, $start, $length = null, $encoding = null )
+    {
+        if ( $start < 0 ) {
+            $start = self::strlen( $s, $encoding ) + $start;
+            if ( $start < 0 ) {
+                $start = 0;
+            }
+        }
+
+        if ( null === $length ) {
+            $length = 2147483647;
+        } elseif ( $length < 0 ) {
+            $length = \iconv_strlen( $s, $encoding ) + $length - $start;
+            if ( $length < 0 ) {
+                return '';
+            }
+        }
+
+        return (string) \iconv_substr( $s, $start, $length, $encoding );
+    }
+}

--- a/tests/test-ao.php
+++ b/tests/test-ao.php
@@ -1833,4 +1833,202 @@ MARKUP;
         $actual = $instance->getcontent();
         $this->assertEquals( $expected, $actual );
     }
+
+    public function test_utils_mbstring_iconv_availabilty_overriding()
+    {
+        $orig     = autoptimizeUtils::iconv_available();
+        $opposite = ! $orig;
+
+        $this->assertSame( $orig, autoptimizeUtils::iconv_available() );
+        // Override works...
+        $this->assertSame( $opposite, autoptimizeUtils::iconv_available( $opposite ) );
+        // And override remains cached as the last version
+        $this->assertSame( $opposite, autoptimizeUtils::iconv_available() );
+
+        $orig     = autoptimizeUtils::mbstring_available();
+        $opposite = ! $orig;
+
+        $this->assertSame( $orig, autoptimizeUtils::mbstring_available() );
+        // Override works...
+        $this->assertSame( $opposite, autoptimizeUtils::mbstring_available( $opposite ) );
+        // And override remains cached as the last version
+        $this->assertSame( $opposite, autoptimizeUtils::mbstring_available() );
+    }
+
+    public function test_utils_mbstring_basics()
+    {
+        // Turn off iconv, turn on mbstring usage
+        autoptimizeUtils::mbstring_available( true );
+        autoptimizeUtils::iconv_available( false );
+
+        $this->assertSame( 2, autoptimizeUtils::strlen( "\x00\xFF", 'ASCII' ) );
+        $this->assertSame( 2, autoptimizeUtils::strlen( "\x00\xFF", 'CP850' ) );
+        $this->assertSame( 3, autoptimizeUtils::strlen( '한국어' ) );
+
+        $this->assertFalse( @autoptimizeUtils::strpos( 'abc', '' ) );
+        $this->assertFalse( @autoptimizeUtils::strpos( 'abc', 'a', -1 ) );
+        $this->assertFalse( autoptimizeUtils::strpos( 'abc', 'd' ) );
+        $this->assertFalse( autoptimizeUtils::strpos( 'abc', 'a', 3 ) );
+        $this->assertSame( 1, autoptimizeUtils::strpos( '한국어', '국' ) );
+    }
+
+    public function test_utils_iconv_basics()
+    {
+        // Turn off mbstring, turn on iconv
+        autoptimizeUtils::mbstring_available( false );
+        autoptimizeUtils::iconv_available( true );
+
+        $this->assertSame( 1, autoptimizeUtils::strpos( '11--', '1-', 0, 'UTF-8' ) );
+        $this->assertSame( 2, autoptimizeUtils::strpos( '-11--', '1-', 0, 'UTF-8' ) );
+        $this->assertSame( 4, autoptimizeUtils::strlen( 'déjà', 'UTF-8' ) );
+        $this->assertSame( 3, autoptimizeUtils::strlen( '한국어', 'UTF-8' ) );
+    }
+
+    /**
+     * @dataProvider provider_utils_substr_replace
+     */
+    function test_utils_substr_replace_basics_mbstring($s, $repl, $start, $len, $expected)
+    {
+        // Force mbstring code path...
+        autoptimizeUtils::mbstring_available( true );
+        autoptimizeUtils::iconv_available( false );
+        $this->assertEquals( $expected, autoptimizeUtils::substr_replace( $s, $repl, $start, $len ) );
+    }
+
+    /**
+     * @dataProvider provider_utils_substr_replace
+     */
+    function test_utils_substr_replace_basics_iconv($s, $repl, $start, $len, $expected)
+    {
+        // Force iconv code path...
+        autoptimizeUtils::mbstring_available( false );
+        autoptimizeUtils::iconv_available( true );
+        $this->assertEquals( $expected, autoptimizeUtils::substr_replace( $s, $repl, $start, $len ) );
+    }
+
+    public function provider_utils_substr_replace()
+    {
+        $str  = 'try this';
+        $repl = 'bala ';
+
+        return [
+            [
+                $str,
+                $repl,
+                2,
+                null,
+                'trbala ',
+            ],
+            [
+                $str,
+                $repl,
+                2,
+                3,
+                'trbala his',
+            ],
+            [
+                $str,
+                $repl,
+                2,
+                0,
+                'trbala y this',
+            ],
+            [
+                $str,
+                $repl,
+                2,
+                -2,
+                'trbala is',
+            ],
+        ];
+    }
+
+    function test_mb_substr_replace_with_ascii_input_string()
+    {
+        autoptimizeUtils::mbstring_available( false );
+        autoptimizeUtils::iconv_available( true );
+
+        $str = 'Ascii';
+
+        $this->assertSame( 'Añ', autoptimizeUtils::substr_replace( $str, 'ñ', 1 ) );
+        $this->assertSame( 'ñcii', autoptimizeUtils::substr_replace( $str, 'ñ', 0, 2 ) );
+        $this->assertSame( 'Asñx', autoptimizeUtils::substr_replace( $str, 'ñx', 2, 3 ) );
+        $this->assertSame( 'Asz', autoptimizeUtils::substr_replace( $str, 'z', 2, 10 ) );
+        $this->assertSame( 'Añii', autoptimizeUtils::substr_replace( $str, 'ñ', 1, 2 ) );
+    }
+
+    function test_mb_substr_replace_with_utf8_input_string()
+    {
+        autoptimizeUtils::mbstring_available( true );
+        autoptimizeUtils::iconv_available( false );
+
+        $str = 'âønæë';
+
+        $this->assertSame( 'âñ', autoptimizeUtils::substr_replace( $str, 'ñ', 1 ) ); // No length.
+        $this->assertSame( 'ñnæë', autoptimizeUtils::substr_replace( $str, 'ñ', 0, 2 ) );
+        $this->assertSame( 'âøñx', autoptimizeUtils::substr_replace( $str, 'ñx', 2, 3 ) );
+        $this->assertSame( 'âøz', autoptimizeUtils::substr_replace( $str, 'z', 2, 10 ) ); // Length larger than possible...
+        $this->assertSame( 'âñæë', autoptimizeUtils::substr_replace( $str, 'ñ', 1, 2 ) );
+    }
+
+    function test_iconv_substr_replace_with_ascii_input_string()
+    {
+        autoptimizeUtils::mbstring_available( false );
+        autoptimizeUtils::iconv_available( true );
+
+        $str = 'Ascii';
+
+        $this->assertSame( 'Añ', autoptimizeUtils::substr_replace( $str, 'ñ', 1 ) );
+        $this->assertSame( 'ñcii', autoptimizeUtils::substr_replace( $str, 'ñ', 0, 2 ) );
+        $this->assertSame( 'Asñx', autoptimizeUtils::substr_replace( $str, 'ñx', 2, 3 ) );
+        $this->assertSame( 'Asz', autoptimizeUtils::substr_replace( $str, 'z', 2, 10 ) );
+        $this->assertSame( 'Añii', autoptimizeUtils::substr_replace( $str, 'ñ', 1, 2 ) );
+    }
+
+    function test_iconv_substr_replace_with_utf8_input_string()
+    {
+        autoptimizeUtils::mbstring_available( false );
+        autoptimizeUtils::iconv_available( true );
+
+        $str = 'âønæë';
+
+        $this->assertSame( 'âñ', autoptimizeUtils::substr_replace( $str, 'ñ', 1 ) ); // No length.
+        $this->assertSame( 'ñnæë', autoptimizeUtils::substr_replace( $str, 'ñ', 0, 2 ) );
+        $this->assertSame( 'âøñx', autoptimizeUtils::substr_replace( $str, 'ñx', 2, 3 ) );
+        $this->assertSame( 'âøz', autoptimizeUtils::substr_replace( $str, 'z', 2, 10 ) ); // Length larger than possible...
+        $this->assertSame( 'âñæë', autoptimizeUtils::substr_replace( $str, 'ñ', 1, 2 ) );
+    }
+
+    function test_default_substr_replace_with_ascii_input_string()
+    {
+        // Disabling both mbstring and iconv approach, falling back to substr_replace...
+        autoptimizeUtils::mbstring_available( false );
+        autoptimizeUtils::iconv_available( false );
+
+        $str = 'Ascii';
+
+        $this->assertSame( 'Añ', autoptimizeUtils::substr_replace( $str, 'ñ', 1 ) );
+        $this->assertSame( 'ñcii', autoptimizeUtils::substr_replace( $str, 'ñ', 0, 2 ) );
+        $this->assertSame( 'Asñx', autoptimizeUtils::substr_replace( $str, 'ñx', 2, 3 ) );
+        $this->assertSame( 'Asz', autoptimizeUtils::substr_replace( $str, 'z', 2, 10 ) );
+        $this->assertSame( 'Añii', autoptimizeUtils::substr_replace( $str, 'ñ', 1, 2 ) );
+    }
+
+    function test_default_substr_replace_with_utf8_input_string()
+    {
+        // Disabling both mbstring and iconv approach, falling back to substr_replace...
+        autoptimizeUtils::mbstring_available( false );
+        autoptimizeUtils::iconv_available( false );
+
+        // This is really impossible to make work properly, since
+        // any start/len parameters we give are working with bytes instead
+        // of characters, shit just breaks.
+        $str = 'âønæë';
+
+        //$this->assertSame( '�ñ', autoptimizeUtils::substr_replace( $str, 'ñ', 1 ) ); // No length.
+        //$this->assertSame( 'ñ�næë', autoptimizeUtils::substr_replace( $str, 'ñ', 1, 2 ) );
+        $this->assertSame( 'ñønæë', autoptimizeUtils::substr_replace( $str, 'ñ', 0, 2 ) );
+        $this->assertSame( 'âñxæë', autoptimizeUtils::substr_replace( $str, 'ñx', 2, 3 ) );
+        $this->assertSame( 'âz', autoptimizeUtils::substr_replace( $str, 'z', 2, 10 ) ); // Length larger than possible...
+    }
 }


### PR DESCRIPTION
* uses mbstring/iconv stuff if it's available
* if neither exists, fall back to \substr_compare() which
was how it worked up to this point
* removed one extra needless strpos() call in autoptimizeBase::inject_in_html()
* some minor cs fixes
* tests covering the newly added stuff

Hopefully performance doesn't suffer...

Might help with #154 