### PR TITLE
Optimize Images

### DIFF
--- a/classes/autoptimizeConfig.php
+++ b/classes/autoptimizeConfig.php
@@ -720,6 +720,7 @@ input[type=url]:invalid {color: red; border-color:red;} .form-table th{font-weig
             'autoptimize_extra_radio_field_4'    => '1',
             'autoptimize_extra_text_field_2'     => '',
             'autoptimize_extra_text_field_3'     => '',
+            'autoptimize_extra_checkbox_field_5' => '0',            
         );
 
         return $defaults;

--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -484,14 +484,14 @@ class autoptimizeExtra
         $imgopt_size     = '';
 
         if ( $width && 0 !== $width ) {
-            $imgopt_size = 'w_' . $width;
+            $imgopt_size = ',w_' . $width;
         }
 
         if ( $height && 0 !== $height ) {
             $imgopt_size .= ',h_' . $height;
         }
 
-        $url = $imgopt_base_url . ',' . $imgopt_size . '/' . $orig_url;
+        $url = $imgopt_base_url . $imgopt_size . '/' . $orig_url;
 
         return $url;
     }

--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -349,10 +349,8 @@ class autoptimizeExtra
          * smart switch between shortpixel hosts (could).
          */
 
+        $shortpix_base_url = $this->get_shortpixel_url();
         $site_host         = parse_url( site_url(), PHP_URL_HOST );
-        $quality           = apply_filters( 'autoptimize_filter_extra_images_quality', 'q_glossy' ); // values: q_lossy, q_lossless, q_glossy.
-        $ret_val           = apply_filters( 'autoptimize_filter_extra_images_wait', 'ret_img' ); // values: ret_wait, ret_img, ret_json, ret_blank.
-        $shortpix_base_url = 'https://api-ai.shortpixel.com/client/' . $quality . ',' . $ret_val;
         $to_replace        = array();
 
         // extract img tags.
@@ -410,9 +408,7 @@ class autoptimizeExtra
 
     public function filter_optimize_css_images( $in )
     {
-        $quality           = apply_filters( 'autoptimize_filter_extra_images_quality', 'q_glossy' ); // values: q_lossy, q_lossless, q_glossy.
-        $ret_val           = apply_filters( 'autoptimize_filter_extra_images_wait', 'ret_img' ); // values: ret_wait, ret_img, ret_json, ret_blank.
-        $shortpix_base_url = 'https://api-ai.shortpixel.com/client/' . $quality . ',' . $ret_val;
+        $shortpix_base_url = $this->get_shortpixel_url();
 
         if ( strpos( $in, 'http' ) !== 0 && strpos( $in, '//' ) === 0 ) {
             // fixme: also take /wp-content/uploads/image.png into account.
@@ -426,6 +422,14 @@ class autoptimizeExtra
         } else {
             return $in;
         }
+    }
+
+    public function get_shortpixel_url()
+    {
+        $quality           = apply_filters( 'autoptimize_filter_extra_images_quality', 'q_glossy' ); // values: q_lossy, q_lossless, q_glossy.
+        $ret_val           = apply_filters( 'autoptimize_filter_extra_images_wait', 'ret_img' ); // values: ret_wait, ret_img, ret_json, ret_blank.
+        $shortpix_base_url = 'https://api-ai.shortpixel.com/client/' . $quality . ',' . $ret_val;
+        return $shortpix_base_url;
     }
 
     public function admin_menu()

--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -536,6 +536,23 @@ class autoptimizeExtra
         <span id='autoptimize_extra_descr'><?php _e( 'The following settings can improve your site\'s performance even more.', 'autoptimize' ); ?></span>
         <table class="form-table">
             <tr>
+                <th scope="row"><?php _e( 'Google Fonts', 'autoptimize' ); ?></th>
+                <td>
+                    <input type="radio" name="autoptimize_extra_settings[autoptimize_extra_radio_field_4]" value="1" <?php if ( ! in_array( $gfonts, array( 2, 3, 4 ) ) ) { echo 'checked'; } ?> ><?php _e( 'Leave as is', 'autoptimize' ); ?><br/>
+                    <input type="radio" name="autoptimize_extra_settings[autoptimize_extra_radio_field_4]" value="2" <?php checked( 2, $gfonts, true ); ?> ><?php _e( 'Remove Google Fonts', 'autoptimize' ); ?><br/>
+                    <input type="radio" name="autoptimize_extra_settings[autoptimize_extra_radio_field_4]" value="3" <?php checked( 3, $gfonts, true ); ?> ><?php _e( 'Combine and link in head (fonts load fast but are render-blocking)', 'autoptimize' ); ?><br/>
+                    <input type="radio" name="autoptimize_extra_settings[autoptimize_extra_radio_field_4]" value="5" <?php checked( 5, $gfonts, true ); ?> ><?php _e( 'Combine and preload in head (fonts load late, but are not render-blocking)', 'autoptimize' ); ?><br/>
+                    <input type="radio" name="autoptimize_extra_settings[autoptimize_extra_radio_field_4]" value="4" <?php checked( 4, $gfonts, true ); ?> ><?php _e( 'Combine and load fonts asynchronously with <a href="https://github.com/typekit/webfontloader#readme" target="_blank">webfont.js</a>', 'autoptimize' ); ?><br/>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( 'Optimize Images', 'autoptimize' ); ?></th>
+                <td>
+                    <label><input type='checkbox' name='autoptimize_extra_settings[autoptimize_extra_checkbox_field_5]' <?php if ( ! empty( $options['autoptimize_extra_checkbox_field_5'] ) && '1' === $options['autoptimize_extra_checkbox_field_5'] ) { echo 'checked="checked"'; } ?> value='1'><?php _e( 'Optimizes images using an image optimizing proxy.', 'autoptimize' ); ?></label>
+                    <?php echo apply_filters( 'autoptimize_extra_imgopt_settings_copy', '<p>' . __( 'Free service provided by Shortpixel during Autoptimize 2.4 Beta cycle. After the official 2.4 release this will remain free up until a still to be defined threshold per domain, after which additional service can be purchased at Shortpixel. Usage of this feature is subject to Shortpixel\'s', 'autoptimize' ) . ' <a href="https://shortpixel.com/tos" target="_blank">Terms of Use</a> ' . __( 'and', 'autoptimize' ) . ' <a href="https://shortpixel.com/privacy" target="_blank">Privacy policy</a>.</p>' ); ?>
+                </td>
+            </tr>
+            <tr>
                 <th scope="row"><?php _e( 'Remove emojis', 'autoptimize' ); ?></th>
                 <td>
                     <label><input type='checkbox' name='autoptimize_extra_settings[autoptimize_extra_checkbox_field_1]' <?php if ( ! empty( $options['autoptimize_extra_checkbox_field_1'] ) && '1' === $options['autoptimize_extra_checkbox_field_1'] ) { echo 'checked="checked"'; } ?> value='1'><?php _e( 'Removes WordPress\' core emojis\' inline CSS, inline JavaScript, and an otherwise un-autoptimized JavaScript file.', 'autoptimize' ); ?></label>
@@ -545,16 +562,6 @@ class autoptimizeExtra
                 <th scope="row"><?php _e( 'Remove query strings from static resources', 'autoptimize' ); ?></th>
                 <td>
                     <label><input type='checkbox' name='autoptimize_extra_settings[autoptimize_extra_checkbox_field_0]' <?php if ( ! empty( $options['autoptimize_extra_checkbox_field_0'] ) && '1' === $options['autoptimize_extra_checkbox_field_0'] ) { echo 'checked="checked"'; } ?> value='1'><?php _e( 'Removing query strings (or more specificaly the <code>ver</code> parameter) will not improve load time, but might improve performance scores.', 'autoptimize' ); ?></label>
-                </td>
-            </tr>
-            <tr>
-                <th scope="row"><?php _e( 'Google Fonts', 'autoptimize' ); ?></th>
-                <td>
-                    <input type="radio" name="autoptimize_extra_settings[autoptimize_extra_radio_field_4]" value="1" <?php if ( ! in_array( $gfonts, array( 2, 3, 4 ) ) ) { echo 'checked'; } ?> ><?php _e( 'Leave as is', 'autoptimize' ); ?><br/>
-                    <input type="radio" name="autoptimize_extra_settings[autoptimize_extra_radio_field_4]" value="2" <?php checked( 2, $gfonts, true ); ?> ><?php _e( 'Remove Google Fonts', 'autoptimize' ); ?><br/>
-                    <input type="radio" name="autoptimize_extra_settings[autoptimize_extra_radio_field_4]" value="3" <?php checked( 3, $gfonts, true ); ?> ><?php _e( 'Combine and link in head (fonts load fast but are render-blocking)', 'autoptimize' ); ?><br/>
-                    <input type="radio" name="autoptimize_extra_settings[autoptimize_extra_radio_field_4]" value="5" <?php checked( 5, $gfonts, true ); ?> ><?php _e( 'Combine and preload in head (fonts load late, but are not render-blocking)', 'autoptimize' ); ?><br/>
-                    <input type="radio" name="autoptimize_extra_settings[autoptimize_extra_radio_field_4]" value="4" <?php checked( 4, $gfonts, true ); ?> ><?php _e( 'Combine and load fonts asynchronously with <a href="https://github.com/typekit/webfontloader#readme" target="_blank">webfont.js</a>', 'autoptimize' ); ?><br/>
                 </td>
             </tr>
             <tr>
@@ -582,13 +589,6 @@ class autoptimizeExtra
                             echo sprintf( ' <a href="' . $asj_install_url . '">%s</a>', __( 'Click here to install and activate it.', 'autoptimize' ) );
                     }
                     ?>
-                </td>
-            </tr>
-            <tr>
-                <th scope="row"><?php _e( 'Optimize Images', 'autoptimize' ); ?></th>
-                <td>
-                    <label><input type='checkbox' name='autoptimize_extra_settings[autoptimize_extra_checkbox_field_5]' <?php if ( ! empty( $options['autoptimize_extra_checkbox_field_5'] ) && '1' === $options['autoptimize_extra_checkbox_field_5'] ) { echo 'checked="checked"'; } ?> value='1'><?php _e( 'Optimizes images using an image optimizing proxy.', 'autoptimize' ); ?></label>
-                    <?php echo apply_filters( 'autoptimize_extra_imgopt_settings_copy', '<p>' . __( 'Free service provided by Shortpixel during Autoptimize 2.4 Beta cycle. After the official 2.4 release this will remain free up until a still to be defined threshold per domain, after which additional service can be purchased at Shortpixel. Usage of this feature is subject to Shortpixel\'s', 'autoptimize' ) . ' <a href="https://shortpixel.com/tos" target="_blank">Terms of Use</a> ' . __( 'and', 'autoptimize' ) . ' <a href="https://shortpixel.com/privacy" target="_blank">Privacy policy</a>.</p>' ); ?>
                 </td>
             </tr>
             <tr>

--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -565,7 +565,7 @@ class autoptimizeExtra
                 <th scope="row"><?php _e( 'Optimize Images', 'autoptimize' ); ?></th>
                 <td>
                     <label><input type='checkbox' name='autoptimize_extra_settings[autoptimize_extra_checkbox_field_5]' <?php if ( ! empty( $options['autoptimize_extra_checkbox_field_5'] ) && '1' === $options['autoptimize_extra_checkbox_field_5'] ) { echo 'checked="checked"'; } ?> value='1'><?php _e( "Optimizes images using Shortpixel's image optimizing proxy.", 'autoptimize' ); ?></label>
-                    <p><?php _e( 'Free service during Autoptimize 2.4 Beta cycle. After the official 2.4 release this will remain free up until a still to be defined threshold per domain, after which additional service can be purchased at Shortpixel. Usage of this feature is subject to Shortpixel\'s', 'autoptimize' ); ?> <a href="https://shortpixel.com/tos" target="_blank">Terms of Use</a>.</p>
+                    <p><?php _e( 'Free service during Autoptimize 2.4 Beta cycle. After the official 2.4 release this will remain free up until a still to be defined threshold per domain, after which additional service can be purchased at Shortpixel. Usage of this feature is subject to Shortpixel\'s', 'autoptimize' ); ?> <a href="https://shortpixel.com/tos" target="_blank">Terms of Use</a> <?php _e('and','autoptimize'); ?> <a href="https://shortpixel.com/privacy" target="_blank">Privacy policy</a>.</p>
                 </td>
             </tr>
             <tr>

--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -339,13 +339,13 @@ class autoptimizeExtra
     public function filter_optimize_images( $in )
     {
         /*
-         * Fix me (still to do):
+         * fixme (still to do):
          *
-         * picture element (could).
-         * filter to exclude images (should).
-         * filter for critical CSS (could).
-         * preconnect to img proxy host (should).
          * gallery (see shortpixel example code) (must).
+         * filter to exclude images (should).
+         * preconnect to img proxy host (should).
+         * picture element (could).
+         * filter for critical CSS (could).
          * smart switch between shortpixel hosts (could).
          */
 

--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -341,7 +341,6 @@ class autoptimizeExtra
         /*
          * fixme (still to do):
          *
-         * gallery (see shortpixel example code) (must).
          * filter to exclude images (should).
          * preconnect to img proxy host (should).
          * picture element (could).
@@ -403,7 +402,16 @@ class autoptimizeExtra
                 }
             }
         }
-        return str_replace( array_keys( $to_replace ), array_values( $to_replace ), $in );
+        $out = str_replace( array_keys( $to_replace ), array_values( $to_replace ), $in );
+
+        // img thumbnails in e.g. woocommerce
+        $out = preg_replace_callback(
+            '/\<div.+?data-thumb\=(?:\"|\')(.+?)(?:\"|\')(?:.+?)\>\<\/div\>/s',
+            array( $this, 'replace_data_thumbs' ),    
+            $out
+        );
+
+        return $out;
     }
 
     public function filter_optimize_css_images( $in )
@@ -430,6 +438,10 @@ class autoptimizeExtra
         $ret_val           = apply_filters( 'autoptimize_filter_extra_images_wait', 'ret_img' ); // values: ret_wait, ret_img, ret_json, ret_blank.
         $shortpix_base_url = 'https://api-ai.shortpixel.com/client/' . $quality . ',' . $ret_val;
         return $shortpix_base_url;
+    }
+
+    public function replace_data_thumbs( $matches ) {
+        return str_replace( $matches[1], $this->get_shortpixel_url() . ',w_150,h_150/' . $matches[1], $matches[0] );
     }
 
     public function admin_menu()

--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -148,8 +148,12 @@ class autoptimizeExtra
 
         // Optimize Images!
         if ( ! empty( $options['autoptimize_extra_checkbox_field_5'] ) ) {
-            add_filter( 'autoptimize_html_after_minify', array( $this, 'filter_optimize_images' ), 10, 1 );
-            add_filter( 'autoptimize_filter_base_replace_cdn', array( $this, 'filter_optimize_css_images' ), 10, 1 );
+            if ( apply_filters( 'autoptimize_filter_extra_images', true ) ) {
+                add_filter( 'autoptimize_html_after_minify', array( $this, 'filter_optimize_images' ), 10, 1 );
+            }
+            if ( apply_filters( 'autoptimize_filter_extra_cssimages', true ) ) {
+                add_filter( 'autoptimize_filter_base_replace_cdn', array( $this, 'filter_optimize_css_images' ), 10, 1 );
+            }
         }
     }
 
@@ -335,21 +339,19 @@ class autoptimizeExtra
     public function filter_optimize_images( $in )
     {
         /*
-         * Still TO DO:
+         * Fix me (still to do):
          *
-         * picture element?
-         * filter to exclude images?
-         * filter to enable/ disable css background img vs 'normal' image stuff
-         * filters to change quality & ret_val
-         * add_filter('autoptimize_filter_css_defer_inline','shortpixify_ccss_images');
-         * preconnect to img proxy host
-         * gallery (see shortpixel example code)
-         * smart switch between shortpixel hosts
+         * picture element (could).
+         * filter to exclude images (should).
+         * filter for critical CSS (could).
+         * preconnect to img proxy host (should).
+         * gallery (see shortpixel example code) (must).
+         * smart switch between shortpixel hosts (could).
          */
 
         $site_host         = parse_url( site_url(), PHP_URL_HOST );
-        $quality           = 'q_glossy';
-        $ret_val           = 'ret_img';
+        $quality           = apply_filters( 'autoptimize_filter_extra_images_quality', 'q_glossy' ); // values: q_lossy, q_lossless, q_glossy.
+        $ret_val           = apply_filters( 'autoptimize_filter_extra_images_wait', 'ret_img' ); // values: ret_wait, ret_img, ret_json, ret_blank.
         $shortpix_base_url = 'https://api-ai.shortpixel.com/client/' . $quality . ',' . $ret_val;
         $to_replace        = array();
 
@@ -408,8 +410,8 @@ class autoptimizeExtra
 
     public function filter_optimize_css_images( $in )
     {
-        $quality           = 'q_glossy';
-        $ret_val           = 'ret_img';
+        $quality           = apply_filters( 'autoptimize_filter_extra_images_quality', 'q_glossy' ); // values: q_lossy, q_lossless, q_glossy.
+        $ret_val           = apply_filters( 'autoptimize_filter_extra_images_wait', 'ret_img' ); // values: ret_wait, ret_img, ret_json, ret_blank.
         $shortpix_base_url = 'https://api-ai.shortpixel.com/client/' . $quality . ',' . $ret_val;
 
         if ( strpos( $in, 'http' ) !== 0 && strpos( $in, '//' ) === 0 ) {
@@ -514,6 +516,7 @@ class autoptimizeExtra
                 <th scope="row"><?php _e( 'Optimize Images', 'autoptimize' ); ?></th>
                 <td>
                     <label><input type='checkbox' name='autoptimize_extra_settings[autoptimize_extra_checkbox_field_5]' <?php if ( ! empty( $options['autoptimize_extra_checkbox_field_5'] ) && '1' === $options['autoptimize_extra_checkbox_field_5'] ) { echo 'checked="checked"'; } ?> value='1'><?php _e( "Optimizes images using Shortpixel's image optimizing proxy.", 'autoptimize' ); ?></label>
+                    <p><?php _e( 'Free service during Autoptimize 2.4 Beta cycle. After the official 2.4 release this will remain free up until a still to be defined threshold per domain, after which additional service can be purchased at Shortpixel. Usage of this feature is subject to Shortpixel\'s', 'autoptimize' ); ?> <a href="https://shortpixel.com/tos" target="_blank">Terms of Use</a>.</p>
                 </td>
             </tr>
             <tr>

--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -342,7 +342,6 @@ class autoptimizeExtra
          * fixme: functional stuff
          *
          * preconnect to img proxy host (should).
-         * rename all vars and functions not to have "shortpixel" in name (should).
          * separate reusable 'create_imgopt_link' function with filter to allow easier switch to other partners (should).
          * picture element (could).
          * filter for critical CSS (could).
@@ -370,23 +369,23 @@ class autoptimizeExtra
                     foreach ( $srcsets as $indiv_srcset ) {
                         $indiv_srcset_parts = explode( ' ', trim( $indiv_srcset ) );
                         if ( $indiv_srcset_parts[1] && rtrim( $indiv_srcset_parts[1], 'w' ) !== $indiv_srcset_parts[1] ) {
-                            $shortpix_size = 'w_' . rtrim( $indiv_srcset_parts[1], 'w' );
+                            $imgopt_size = 'w_' . rtrim( $indiv_srcset_parts[1], 'w' );
                         }
                         if ( $this->can_optimize_image( $indiv_srcset_parts[0] ) ) {
-                            $shortpix_url            = $imgopt_base_url . ',' . $shortpix_size . '/' . $indiv_srcset_parts[0];
-                            $tag                     = str_replace( $indiv_srcset_parts[0], $shortpix_url, $tag );
+                            $imgopt_url            = $imgopt_base_url . ',' . $imgopt_size . '/' . $indiv_srcset_parts[0];
+                            $tag                     = str_replace( $indiv_srcset_parts[0], $imgopt_url, $tag );
                             $to_replace[ $orig_tag ] = $tag;
                         }
                     }
                 }
 
                 // proceed with img src.
-                // first get width and height and add to $shortpix_size.
+                // first get width and height and add to $imgopt_size.
                 if ( preg_match( '#width=("|\')(.*)("|\')#Usmi', $tag, $width ) ) {
-                    $shortpix_size = 'w_' . $width[2];
+                    $imgopt_size = 'w_' . $width[2];
                 }
                 if ( preg_match( '#height=("|\')(.*)("|\')#Usmi', $tag, $height ) ) {
-                    $shortpix_size .= ',h_' . $height[2];
+                    $imgopt_size .= ',h_' . $height[2];
                 }
 
                 // and then find and change actual images src.
@@ -394,9 +393,9 @@ class autoptimizeExtra
                     $full_src = $url[0];
                     $url      = $url[2];
                     if ( $this->can_optimize_image( $url ) ) {
-                        $shortpix_url            = $imgopt_base_url . ',' . $shortpix_size . '/' . $url;
-                        $full_shortpix_src       = str_replace( $url, $shortpix_url, $full_src );
-                        $to_replace[ $orig_tag ] = str_replace( '<!--src-->', $full_shortpix_src, $tag );
+                        $imgopt_url            = $imgopt_base_url . ',' . $imgopt_size . '/' . $url;
+                        $full_imgopt_src       = str_replace( $url, $imgopt_url, $full_src );
+                        $to_replace[ $orig_tag ] = str_replace( '<!--src-->', $full_imgopt_src, $tag );
                     } else {
                         $to_replace[ $orig_tag ] = str_replace( '<!--src-->', $full_src, $tag );
                     }

--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -145,6 +145,12 @@ class autoptimizeExtra
         if ( ! empty( $options['autoptimize_extra_text_field_2'] ) || has_filter( 'autoptimize_extra_filter_tobepreconn' ) ) {
             add_filter( 'wp_resource_hints', array( $this, 'filter_preconnect' ), 10, 2 );
         }
+        
+        // Optimize Images!
+        if ( ! empty( $options['autoptimize_extra_checkbox_field_5'] ) ) {
+            add_filter( 'autoptimize_html_after_minify', array( $this, 'filter_optimize_images' ), 10, 1 );
+            add_filter( 'autoptimize_filter_base_replace_cdn', array( $this, 'filter_optimize_css_images' ), 10, 1 );
+        }
     }
 
     public function filter_remove_emoji_dns_prefetch( $urls, $relation_type )
@@ -326,6 +332,98 @@ class autoptimizeExtra
         return $in;
     }
 
+    public function filter_optimize_images( $in )
+    {
+        /*
+         * Still TO DO:
+         *
+         * picture element?
+         * filter to exclude images?
+         * filter to enable/ disable css background img vs 'normal' image stuff
+         * filters to change quality & ret_val
+         * add_filter('autoptimize_filter_css_defer_inline','shortpixify_ccss_images');
+         * preconnect to img proxy host
+         * gallery (see shortpixel example code)
+         * smart switch between shortpixel hosts
+         */
+
+        $site_host = parse_url(site_url(), PHP_URL_HOST);
+        $quality = "q_glossy";
+        $ret_val = "ret_img";
+        $shortpix_base_url = "https://api-ai.shortpixel.com/client/".$quality.",".$ret_val;
+        $to_replace = array();
+        
+        // extract img tags.
+        if ( preg_match_all('#<img[^>]*src[^>]*>#Usmi', $in, $matches) ) {
+            foreach( $matches[0] as $tag ) {
+                $orig_tag = $tag;
+            
+                // extract and hide src (to avoid the URL being overwritten by srcset rewrite).
+                if ( preg_match('#src=("|\')(.*)("|\')#Usmi', $tag, $url) ) {
+                    $tag = str_replace( $url[0], "<!--src-->", $tag );
+                }
+                
+                // first do srcsets.
+                if ( preg_match('#srcset=("|\')(.*)("|\')#Usmi',$tag,$srcset) ) {
+                    $srcset = $orig_srcset = $srcset[2];
+                    $srcsets = explode( ",", $srcset );
+                    foreach ( $srcsets as $indiv_srcset ) {
+                        $indiv_srcset_parts = explode( " ", trim($indiv_srcset) );
+                        if ($indiv_srcset_parts[1] && rtrim($indiv_srcset_parts[1],"w") !== $indiv_srcset_parts[1] ) {
+                            $shortpix_size = "w_".rtrim($indiv_srcset_parts[1],"w");
+                        }
+                        if ( strpos( $indiv_srcset_parts[0], $site_host ) !== false && strpos( $indiv_srcset_parts[0], ".php" ) === false ) {
+                            $shortpix_url = $shortpix_base_url.",".$shortpix_size."/".$indiv_srcset_parts[0];
+                            $to_replace[$orig_tag] = $tag = str_replace( $indiv_srcset_parts[0], $shortpix_url, $tag );
+                        }
+                    }
+                }
+
+                // proceed with img src.
+                // first get width and height and add to $shortpix_size.
+                if ( preg_match('#width=("|\')(.*)("|\')#Usmi',$tag,$width) ) {
+                    $shortpix_size = "w_".$width[2];
+                }
+                if ( preg_match('#height=("|\')(.*)("|\')#Usmi',$tag,$height) ) {
+                    $shortpix_size .= ",h_".$height[2];
+                }
+
+                // and then find and change actual images src.
+                if ( $url ) {
+                    $full_src = $url[0];
+                    $url = $url[2];
+                    if ( strpos( $url, $shortpix_base_url ) === false && strpos( $url, $site_host ) !== false && strpos( $url, ".php" ) === false ) {
+                        // fixme: check this is an image.
+                        $shortpix_url = $shortpix_base_url.",".$shortpix_size."/".$url;
+                        $full_shortpix_src = str_replace( $url, $shortpix_url, $full_src );
+                        $to_replace[$orig_tag] = str_replace( "<!--src-->", $full_shortpix_src, $tag );
+                    }
+                }
+            }
+        } 
+        return str_replace( array_keys( $to_replace ), array_values( $to_replace ), $in );
+    }
+    
+    public function filter_optimize_css_images( $in )
+    {
+        $quality = "q_glossy";
+        $ret_val = "ret_img";
+        $shortpix_base_url = "https://api-ai.shortpixel.com/client/".$quality.",".$ret_val;
+        
+        if ( strpos( $in, "http" ) !== 0 && strpos( $in, "//" ) === 0 ) {
+            // fixme: also take /wp-content/uploads/image.png into account
+            $in = "https:".$in;
+        }
+      
+        $url_path = parse_url($in, PHP_URL_PATH);
+        if ( $url_path !== str_replace( array( '.png', '.gif', '.jpg', '.jpeg' ), '', $url_path ) ) {
+            // fixme: should check against end of string + make sure there's no .php
+            return $shortpix_base_url.'/'.$in;
+        } else {
+            return $in;
+        }
+    }
+
     public function admin_menu()
     {
         add_submenu_page( null, 'autoptimize_extra', 'autoptimize_extra', 'manage_options', 'autoptimize_extra', array( $this, 'options_page' ) );
@@ -408,6 +506,12 @@ class autoptimizeExtra
                             echo sprintf( ' <a href="' . $asj_install_url . '">%s</a>', __( 'Click here to install and activate it.', 'autoptimize' ) );
                     }
                     ?>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><?php _e( 'Optimize Images', 'autoptimize' ); ?></th>
+                <td>
+                    <label><input type='checkbox' name='autoptimize_extra_settings[autoptimize_extra_checkbox_field_5]' <?php if ( ! empty( $options['autoptimize_extra_checkbox_field_5'] ) && '1' === $options['autoptimize_extra_checkbox_field_5'] ) { echo 'checked="checked"'; } ?> value='1'><?php _e( "Optimizes images using Shortpixel's image optimizing proxy.", 'autoptimize' ); ?></label>
                 </td>
             </tr>
             <tr>

--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -339,7 +339,7 @@ class autoptimizeExtra
     public function filter_optimize_images( $in )
     {
         /*
-         * fixme (still to do):
+         * fixme: functional stuff
          *
          * filter to exclude images (should).
          * preconnect to img proxy host (should).

--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -416,10 +416,12 @@ class autoptimizeExtra
     public function filter_optimize_css_images( $in )
     {
         $imgopt_base_url = $this->get_imgopt_url();
+        $parsed_site_url = parse_url( site_url() );
 
         if ( strpos( $in, 'http' ) !== 0 && strpos( $in, '//' ) === 0 ) {
-            // fixme: also take /wp-content/uploads/image.png into account.
-            $in = 'https:' . $in;
+            $in = $parsed_site_url['scheme'] . ':' . $in;
+        } elseif ( strpos( $in, '/' ) === 0 ) {
+            $in = $parsed_site_url['scheme'] . '://' . $parsed_site_url['host'] . $in;
         }
 
         if ( $this->can_optimize_image( $in ) ) {
@@ -467,7 +469,7 @@ class autoptimizeExtra
     }
 
     public function replace_data_thumbs( $matches ) {
-        if ( $this->can_optimize_image( $matches[1] ) ){
+        if ( $this->can_optimize_image( $matches[1] ) ) {
             return str_replace( $matches[1], $this->get_imgopt_url() . ',w_150,h_150/' . $matches[1], $matches[0] );
         } else {
             return $matches[0];

--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -342,6 +342,8 @@ class autoptimizeExtra
          * fixme: functional stuff
          *
          * preconnect to img proxy host (should).
+         * rename all vars and functions not to have "shortpixel" in name (should).
+         * separate reusable 'create_imgopt_link' function with filter to allow easier switch to other partners (should).
          * picture element (could).
          * filter for critical CSS (could).
          * smart switch between shortpixel hosts (could).

--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -150,9 +150,14 @@ class autoptimizeExtra
         if ( ! empty( $options['autoptimize_extra_checkbox_field_5'] ) ) {
             if ( apply_filters( 'autoptimize_filter_extra_imgopt_do', true ) ) {
                 add_filter( 'autoptimize_html_after_minify', array( $this, 'filter_optimize_images' ), 10, 1 );
+                $_imgopt_active = true;
             }
             if ( apply_filters( 'autoptimize_filter_extra_imgopt_do_css', true ) ) {
                 add_filter( 'autoptimize_filter_base_replace_cdn', array( $this, 'filter_optimize_css_images' ), 10, 1 );
+                $_imgopt_active = true;
+            }
+            if ( $_imgopt_active ) {
+                add_filter( 'autoptimize_extra_filter_tobepreconn', array( $this, 'filter_preconnect_imgopt_url' ), 10, 1 );
             }
         }
     }
@@ -341,7 +346,6 @@ class autoptimizeExtra
         /*
          * fixme: functional stuff
          *
-         * preconnect to img proxy host (should).
          * picture element (could).
          * filter for critical CSS (could).
          * smart switch between shortpixel hosts (could).
@@ -498,6 +502,14 @@ class autoptimizeExtra
         } else {
             return $matches[0];
         }
+    }
+
+    public function filter_preconnect_imgopt_url( $in )
+    {
+        $imgopt_url_array = parse_url( $this->get_imgopt_url() );
+        $in[]             = $imgopt_url_array['scheme'] . '://' . $imgopt_url_array['host'];
+
+        return $in;
     }
 
     public function admin_menu()

--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -474,9 +474,9 @@ class autoptimizeExtra
 
     private function build_imgopt_url( $orig_url, $width = 0, $height = 0 )
     {
-        $filtered_url = apply_filters( 'autoptimize_filter_extra_imgopt_build_url', $url, $width, $height );
+        $filtered_url = apply_filters( 'autoptimize_filter_extra_imgopt_build_url', $orig_url, $width, $height );
 
-        if ( $filtered_url !== $url ) {
+        if ( $filtered_url !== $orig_url ) {
             return $filtered_url;
         }
 

--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -372,7 +372,7 @@ class autoptimizeExtra
                             $imgopt_size = 'w_' . rtrim( $indiv_srcset_parts[1], 'w' );
                         }
                         if ( $this->can_optimize_image( $indiv_srcset_parts[0] ) ) {
-                            $imgopt_url            = $imgopt_base_url . ',' . $imgopt_size . '/' . $indiv_srcset_parts[0];
+                            $imgopt_url              = $imgopt_base_url . ',' . $imgopt_size . '/' . $indiv_srcset_parts[0];
                             $tag                     = str_replace( $indiv_srcset_parts[0], $imgopt_url, $tag );
                             $to_replace[ $orig_tag ] = $tag;
                         }
@@ -393,8 +393,8 @@ class autoptimizeExtra
                     $full_src = $url[0];
                     $url      = $url[2];
                     if ( $this->can_optimize_image( $url ) ) {
-                        $imgopt_url            = $imgopt_base_url . ',' . $imgopt_size . '/' . $url;
-                        $full_imgopt_src       = str_replace( $url, $imgopt_url, $full_src );
+                        $imgopt_url              = $imgopt_base_url . ',' . $imgopt_size . '/' . $url;
+                        $full_imgopt_src         = str_replace( $url, $imgopt_url, $full_src );
                         $to_replace[ $orig_tag ] = str_replace( '<!--src-->', $full_imgopt_src, $tag );
                     } else {
                         $to_replace[ $orig_tag ] = str_replace( '<!--src-->', $full_src, $tag );
@@ -565,7 +565,7 @@ class autoptimizeExtra
                 <th scope="row"><?php _e( 'Optimize Images', 'autoptimize' ); ?></th>
                 <td>
                     <label><input type='checkbox' name='autoptimize_extra_settings[autoptimize_extra_checkbox_field_5]' <?php if ( ! empty( $options['autoptimize_extra_checkbox_field_5'] ) && '1' === $options['autoptimize_extra_checkbox_field_5'] ) { echo 'checked="checked"'; } ?> value='1'><?php _e( "Optimizes images using Shortpixel's image optimizing proxy.", 'autoptimize' ); ?></label>
-                    <p><?php _e( 'Free service during Autoptimize 2.4 Beta cycle. After the official 2.4 release this will remain free up until a still to be defined threshold per domain, after which additional service can be purchased at Shortpixel. Usage of this feature is subject to Shortpixel\'s', 'autoptimize' ); ?> <a href="https://shortpixel.com/tos" target="_blank">Terms of Use</a> <?php _e('and','autoptimize'); ?> <a href="https://shortpixel.com/privacy" target="_blank">Privacy policy</a>.</p>
+                    <p><?php _e( 'Free service during Autoptimize 2.4 Beta cycle. After the official 2.4 release this will remain free up until a still to be defined threshold per domain, after which additional service can be purchased at Shortpixel. Usage of this feature is subject to Shortpixel\'s', 'autoptimize' ); ?> <a href="https://shortpixel.com/tos" target="_blank">Terms of Use</a> <?php _e( 'and', 'autoptimize' ); ?> <a href="https://shortpixel.com/privacy" target="_blank">Privacy policy</a>.</p>
                 </td>
             </tr>
             <tr>

--- a/tests/test-ao.php
+++ b/tests/test-ao.php
@@ -2346,4 +2346,24 @@ MARKUP;
 
         remove_all_filters( 'autoptimize_filter_cdn_magic_path_check' );
     }
+    
+    /**
+     * Test image optimization in autoptimizeExtra.php.
+     */
+    public function test_extra_imgopt()
+    {
+        $siteurl = $this->get_urls()['siteurl'];
+
+        $markup = <<<MARKUP
+<img src='$siteurl/wp-content/image.jpg' width='400' height='200'>
+MARKUP;
+
+        $expected = <<<MARKUP
+<img src='https://api-ai.shortpixel.com/client/q_glossy,ret_img,w_400,h_200/$siteurl/wp-content/image.jpg' width='400' height='200'>
+MARKUP;
+
+        $instance = new autoptimizeExtra();
+        $actual = $instance->filter_optimize_images( $markup );
+        $this->assertEquals( $expected, $actual );
+    }
 }


### PR DESCRIPTION
"optimize images" is a new option in "Extra" which will route requests for images (img src, srcsets, css background images and data-thumb attribs) through an image optimizing proxy (in this case provided by Shortpixel but this can be changed through a filter).

The service is provided for free by Shortpixel during the AO beta-cycle and will remain free up until a still to be defined threshold per domain after the beta. If the threshold is reached extra credits will have to be purchased at shortpixel.com.