### PR TITLE
Ditch iconv, default to mbstring replacements being optional

### DIFF
--- a/classes/autoptimizeMain.php
+++ b/classes/autoptimizeMain.php
@@ -128,8 +128,12 @@ class autoptimizeMain
             define( 'AUTOPTIMIZE_SITE_DOMAIN', parse_url( AUTOPTIMIZE_WP_SITE_URL, PHP_URL_HOST ) );
         }
 
-        // disable iconv by default (it's too slow).
-        autoptimizeUtils::iconv_available( false );
+        // Multibyte-capable string replacements are available with a filter.
+        // Also requires 'mbstring' extension.
+        $with_mbstring = apply_filters( 'autoptimize_filter_with_mbstring', false );
+        if ( $with_mbstring ) {
+            autoptimizeUtils::mbstring_available( \extensions_loaded( 'mbstring' ) );
+        }
 
         do_action( 'autoptimize_setup_done' );
     }

--- a/classes/autoptimizeUtils.php
+++ b/classes/autoptimizeUtils.php
@@ -32,28 +32,6 @@ class autoptimizeUtils
     }
 
     /**
-     * Returns true when iconv is available.
-     *
-     * @param bool|null $override Allows overriding the decision.
-     *
-     * @return bool
-     */
-    public static function iconv_available( $override = null )
-    {
-        static $available = null;
-
-        if ( null === $available ) {
-            $available = \extension_loaded( 'iconv' );
-        }
-
-        if ( null !== $override ) {
-            $available = $override;
-        }
-
-        return $available;
-    }
-
-    /**
      * Multibyte-capable strpos() if support is available on the server.
      * If not, it falls back to using \strpos().
      *
@@ -68,8 +46,6 @@ class autoptimizeUtils
     {
         if ( self::mbstring_available() ) {
             return ( null === $encoding ) ? \mb_strpos( $haystack, $needle, $offset ) : \mb_strlen( $haystack, $needle, $offset, $encoding );
-        } elseif ( self::iconv_available() ) {
-            return ( null === $encoding ) ? \iconv_strpos( $haystack, $needle, $offset ) : \iconv_strpos( $haystack, $needle, $offset, $encoding );
         } else {
             return \strpos( $haystack, $needle, $offset );
         }
@@ -77,7 +53,7 @@ class autoptimizeUtils
 
     /**
      * Attempts to return the number of characters in the given $string if
-     * mbstring or iconv is available. Returns the number of bytes
+     * mbstring is available. Returns the number of bytes
      * (instead of characters) as fallback.
      *
      * @param string      $string   String.
@@ -90,8 +66,6 @@ class autoptimizeUtils
     {
         if ( self::mbstring_available() ) {
             return ( null === $encoding ) ? \mb_strlen( $string ) : \mb_strlen( $string, $encoding );
-        } elseif ( self::iconv_available() ) {
-            return ( null === $encoding ) ? @iconv_strlen( $string ) : @iconv_strlen( $string, $encoding );
         } else {
             return \strlen( $string );
         }
@@ -100,7 +74,7 @@ class autoptimizeUtils
     /**
      * Our wrapper around implementations of \substr_replace()
      * that attempts to not break things horribly if at all possible.
-     * Uses mbstring and/or iconv if available, before falling back to regular
+     * Uses mbstring if available, before falling back to regular
      * substr_replace() (which works just fine in the majority of cases).
      *
      * @param string      $string      String.
@@ -146,68 +120,9 @@ class autoptimizeUtils
             }
 
             return "{$leader}{$replacement}{$trailer}";
-        } elseif ( self::iconv_available() ) {
-            $strlen = self::strlen( $string, $encoding );
-
-            if ( $start < 0 ) {
-                $start = \max( 0, $strlen + $start );
-                $start = $strlen + $start;
-                if ( $start < 0 ) {
-                    $start = 0;
-                }
-            } elseif ( $start > $strlen ) {
-                $start = $strlen;
-            }
-
-            if ( $length < 0 ) {
-                $length = \max( 0, $strlen - $start + $length );
-            } elseif ( null === $length || ( $length > $strlen ) ) {
-                $length = $strlen;
-            }
-
-            if ( ( $start + $length ) > $strlen ) {
-                $length = $strlen - $start;
-            }
-
-            if ( null === $encoding ) {
-                return self::iconv_substr( $string, 0, $start ) . $replacement . self::iconv_substr( $string, $start + $length, $strlen - $start - $length );
-            }
-
-            return self::iconv_substr( $string, 0, $start, $encoding ) . $replacement . self::iconv_substr( $string, $start + $length, $strlen - $start - $length, $encoding );
         }
 
         return ( null === $length ) ? \substr_replace( $string, $replacement, $start ) : \substr_replace( $string, $replacement, $start, $length );
-    }
-
-    /**
-     * Wrapper around iconv_substr().
-     *
-     * @param string      $s        String.
-     * @param int         $start    Start offset.
-     * @param int|null    $length   Length.
-     * @param string|null $encoding Encoding.
-     *
-     * @return string
-     */
-    protected static function iconv_substr( $s, $start, $length = null, $encoding = null )
-    {
-        if ( $start < 0 ) {
-            $start = self::strlen( $s, $encoding ) + $start;
-            if ( $start < 0 ) {
-                $start = 0;
-            }
-        }
-
-        if ( null === $length ) {
-            $length = 2147483647;
-        } elseif ( $length < 0 ) {
-            $length = self::strlen( $s, $encoding ) + ( $length - $start );
-            if ( $length < 0 ) {
-                return '';
-            }
-        }
-
-        return (string) ( null === $encoding ) ? \iconv_substr( $s, $start, $length ) : \iconv_substr( $s, $start, $length, $encoding );
     }
 
     /**

--- a/tests/test-ao.php
+++ b/tests/test-ao.php
@@ -2086,17 +2086,8 @@ MARKUP;
         $this->assertEquals( $expected, $actual );
     }
 
-    public function test_utils_mbstring_iconv_availabilty_overriding()
+    public function test_utils_mbstring_availabilty_overriding()
     {
-        $orig     = autoptimizeUtils::iconv_available();
-        $opposite = ! $orig;
-
-        $this->assertSame( $orig, autoptimizeUtils::iconv_available() );
-        // Override works...
-        $this->assertSame( $opposite, autoptimizeUtils::iconv_available( $opposite ) );
-        // And override remains cached as the last version.
-        $this->assertSame( $opposite, autoptimizeUtils::iconv_available() );
-
         $orig     = autoptimizeUtils::mbstring_available();
         $opposite = ! $orig;
 
@@ -2109,9 +2100,8 @@ MARKUP;
 
     public function test_utils_mbstring_basics()
     {
-        // Turn off iconv, turn on mbstring usage.
+        // Turn on mbstring usage.
         autoptimizeUtils::mbstring_available( true );
-        autoptimizeUtils::iconv_available( false );
 
         $this->assertSame( 2, autoptimizeUtils::strlen( "\x00\xFF", 'ASCII' ) );
         $this->assertSame( 2, autoptimizeUtils::strlen( "\x00\xFF", 'CP850' ) );
@@ -2124,18 +2114,6 @@ MARKUP;
         $this->assertSame( 1, autoptimizeUtils::strpos( '한국어', '국' ) );
     }
 
-    public function test_utils_iconv_basics()
-    {
-        // Turn off mbstring, turn on iconv.
-        autoptimizeUtils::mbstring_available( false );
-        autoptimizeUtils::iconv_available( true );
-
-        $this->assertSame( 1, autoptimizeUtils::strpos( '11--', '1-', 0, 'UTF-8' ) );
-        $this->assertSame( 2, autoptimizeUtils::strpos( '-11--', '1-', 0, 'UTF-8' ) );
-        $this->assertSame( 4, autoptimizeUtils::strlen( 'déjà', 'UTF-8' ) );
-        $this->assertSame( 3, autoptimizeUtils::strlen( '한국어', 'UTF-8' ) );
-    }
-
     /**
      * @dataProvider provider_utils_substr_replace
      */
@@ -2143,18 +2121,6 @@ MARKUP;
     {
         // Force mbstring code path...
         autoptimizeUtils::mbstring_available( true );
-        autoptimizeUtils::iconv_available( false );
-        $this->assertEquals( $expected, autoptimizeUtils::substr_replace( $s, $repl, $start, $len ) );
-    }
-
-    /**
-     * @dataProvider provider_utils_substr_replace
-     */
-    function test_utils_substr_replace_basics_iconv( $s, $repl, $start, $len, $expected )
-    {
-        // Force iconv code path...
-        autoptimizeUtils::mbstring_available( false );
-        autoptimizeUtils::iconv_available( true );
         $this->assertEquals( $expected, autoptimizeUtils::substr_replace( $s, $repl, $start, $len ) );
     }
 
@@ -2198,7 +2164,6 @@ MARKUP;
     function test_mb_substr_replace_with_ascii_input_string()
     {
         autoptimizeUtils::mbstring_available( false );
-        autoptimizeUtils::iconv_available( true );
 
         $str = 'Ascii';
 
@@ -2212,35 +2177,6 @@ MARKUP;
     function test_mb_substr_replace_with_utf8_input_string()
     {
         autoptimizeUtils::mbstring_available( true );
-        autoptimizeUtils::iconv_available( false );
-
-        $str = 'âønæë';
-
-        $this->assertSame( 'âñ', autoptimizeUtils::substr_replace( $str, 'ñ', 1 ) ); // No length.
-        $this->assertSame( 'ñnæë', autoptimizeUtils::substr_replace( $str, 'ñ', 0, 2 ) );
-        $this->assertSame( 'âøñx', autoptimizeUtils::substr_replace( $str, 'ñx', 2, 3 ) );
-        $this->assertSame( 'âøz', autoptimizeUtils::substr_replace( $str, 'z', 2, 10 ) ); // Length larger than possible...
-        $this->assertSame( 'âñæë', autoptimizeUtils::substr_replace( $str, 'ñ', 1, 2 ) );
-    }
-
-    function test_iconv_substr_replace_with_ascii_input_string()
-    {
-        autoptimizeUtils::mbstring_available( false );
-        autoptimizeUtils::iconv_available( true );
-
-        $str = 'Ascii';
-
-        $this->assertSame( 'Añ', autoptimizeUtils::substr_replace( $str, 'ñ', 1 ) );
-        $this->assertSame( 'ñcii', autoptimizeUtils::substr_replace( $str, 'ñ', 0, 2 ) );
-        $this->assertSame( 'Asñx', autoptimizeUtils::substr_replace( $str, 'ñx', 2, 3 ) );
-        $this->assertSame( 'Asz', autoptimizeUtils::substr_replace( $str, 'z', 2, 10 ) );
-        $this->assertSame( 'Añii', autoptimizeUtils::substr_replace( $str, 'ñ', 1, 2 ) );
-    }
-
-    function test_iconv_substr_replace_with_utf8_input_string()
-    {
-        autoptimizeUtils::mbstring_available( false );
-        autoptimizeUtils::iconv_available( true );
 
         $str = 'âønæë';
 
@@ -2253,9 +2189,8 @@ MARKUP;
 
     function test_default_substr_replace_with_ascii_input_string()
     {
-        // Disabling both mbstring and iconv approach, falling back to substr_replace...
+        // Disable mbstring which should fall ack to substr_replace...
         autoptimizeUtils::mbstring_available( false );
-        autoptimizeUtils::iconv_available( false );
 
         $str = 'Ascii';
 
@@ -2268,9 +2203,8 @@ MARKUP;
 
     function test_default_substr_replace_with_utf8_input_string()
     {
-        // Disabling both mbstring and iconv approach, falling back to substr_replace...
+        // Disabling mbstring, falling back to substr_replace...
         autoptimizeUtils::mbstring_available( false );
-        autoptimizeUtils::iconv_available( false );
 
         // This is really impossible to make work properly, since
         // any start/len parameters we give are working with bytes instead


### PR DESCRIPTION
mbstring is now behind a (default false)
`autoptimize_filter_with_mbstring` filter