### PR TITLE
Fix compatibility with AMP plugin's paired/native theme support

### DIFF
--- a/classes/autoptimizeMain.php
+++ b/classes/autoptimizeMain.php
@@ -378,6 +378,11 @@ class autoptimizeMain
      */
     public static function is_amp_markup( $content )
     {
+        // Short-circuit when a function is available to determine whether the response is (or will be) an AMP page.
+        if ( function_exists( 'is_amp_endpoint' ) ) {
+            return is_amp_endpoint();
+        }
+        
         $is_amp_markup = preg_match( '/<html[^>]*(?:amp|⚡)/i', $content );
 
         return (bool) $is_amp_markup;


### PR DESCRIPTION
The AMP plugin as of 1.0 adds theme support, allowing you to take your existing theme templates and stylesheets to serve them as AMP. To achieve this it uses output buffering to capture the generated page and then it process the response to make it valid AMP, including the injection of the `amp` attribute on the root `html` element. It seems there is a conflict with the AO plugin here in that its output buffers are running before the AMP plugin's, resulting in it not detecting that the page will be an AMP page since the AMP plugin hasn't yet injected the `amp` attribute.

This should fix that problem by using the plugin's `is_amp_endpoint()` function if it is available.

Fixes #222.