### PR TITLE
Add Autoptimize compatibility with Multisite

### DIFF
--- a/classes/autoptimizeCacheChecker.php
+++ b/classes/autoptimizeCacheChecker.php
@@ -58,10 +58,10 @@ class autoptimizeCacheChecker
         $stat_array     = autoptimizeCache::stats();
         $cache_size     = round( $stat_array[1] );
         if ( ( $cache_size > $max_size ) && ( $do_cache_check ) ) {
-            update_option( 'autoptimize_cachesize_notice', true );
+            autoptimizeOption::update_option( 'autoptimize_cachesize_notice', true );
             if ( apply_filters( 'autoptimize_filter_cachecheck_sendmail', true ) ) {
                 $home_url  = esc_url( home_url() );
-                $ao_mailto = apply_filters( 'autoptimize_filter_cachecheck_mailto', get_option( 'admin_email', '' ) );
+                $ao_mailto = apply_filters( 'autoptimize_filter_cachecheck_mailto', autoptimizeOption::get_option( 'admin_email', '' ) );
 
                 $ao_mailsubject = __( 'Autoptimize cache size warning', 'autoptimize' ) . ' (' . $home_url . ')';
                 $ao_mailbody    = __( 'Autoptimize\'s cache size is getting big, consider purging the cache. Have a look at https://wordpress.org/plugins/autoptimize/faq/ to see how you can keep the cache size under control.', 'autoptimize' ) . ' (site: ' . $home_url . ')';
@@ -87,11 +87,11 @@ class autoptimizeCacheChecker
 
     public function show_admin_notice()
     {
-        if ( (bool) get_option( 'autoptimize_cachesize_notice', false ) && current_user_can( 'manage_options' ) ) {
+        if ( (bool) autoptimizeOption::get_option( 'autoptimize_cachesize_notice', false ) && current_user_can( 'manage_options' ) ) {
             echo '<div class="notice notice-warning"><p>';
             _e( '<strong>Autoptimize\'s cache size is getting big</strong>, consider purging the cache. Have a look at <a href="https://wordpress.org/plugins/autoptimize/faq/" target="_blank" rel="noopener noreferrer">the Autoptimize FAQ</a> to see how you can keep the cache size under control.', 'autoptimize' );
             echo '</p></div>';
-            update_option( 'autoptimize_cachesize_notice', false );
+            autoptimizeOption::update_option( 'autoptimize_cachesize_notice', false );
         }
 
         // Notice for image proxy usage.

--- a/classes/autoptimizeConfig.php
+++ b/classes/autoptimizeConfig.php
@@ -214,7 +214,11 @@ input[type=url]:invalid {color: red; border-color:red;} .form-table th{font-weig
 
 <ul>
 
-<?php if( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) { ?>
+<?php
+// Only show enable site configuration in network site option.
+$blog_id = get_current_blog_id();
+if( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) && 1 === $blog_id ) { 
+?>
 	<li class="itemDetail">
 	<h2 class="itemTitle"><?php _e('Multisite Options','autoptimize'); ?></h2>
 	<table class="form-table">

--- a/classes/autoptimizeConfig.php
+++ b/classes/autoptimizeConfig.php
@@ -15,7 +15,7 @@ class autoptimizeConfig
     {
         if ( is_admin() ) {
             // Add the admin page and settings.
-			if ( is_multisite() && is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
+			if ( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
 				add_action( 'network_admin_menu', array( $this, 'addmenu' ) );
 			} else {
 				add_action( 'admin_menu', array( $this, 'addmenu' ) );
@@ -643,7 +643,7 @@ if ( function_exists( 'is_plugin_active' ) && ! is_plugin_active( 'autoptimize-c
 
     public function addmenu()
     {
-		if ( is_multisite() && is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
+		if ( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
 			$hook = add_submenu_page( 'settings.php',  __( 'Autoptimize Options', 'autoptimize' ), 'Autoptimize', 'manage_network_options', 'autoptimize', array( $this, 'show' ) );
 		} else {
 			$hook = add_options_page( __( 'Autoptimize Options', 'autoptimize' ), 'Autoptimize', 'manage_options', 'autoptimize', array( $this, 'show' ) );

--- a/classes/autoptimizeConfig.php
+++ b/classes/autoptimizeConfig.php
@@ -204,7 +204,7 @@ input[type=url]:invalid {color: red; border-color:red;} .form-table th{font-weig
 
     <?php echo $this->ao_admin_tabs(); ?>
 
-<form method="post" action="options.php">
+<form method="post" action="<?php echo admin_url( 'options.php' ); ?>">
 <?php settings_fields( 'autoptimize' ); ?>
 
 <ul>

--- a/classes/autoptimizeConfig.php
+++ b/classes/autoptimizeConfig.php
@@ -17,7 +17,8 @@ class autoptimizeConfig
             // Add the admin page and settings.
 			if ( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
 				add_action( 'network_admin_menu', array( $this, 'addmenu' ) );
-			} else {
+			} 
+			if ( 'on' === autoptimizeOption::get_option('autoptimize_enable_site_config') ) {
 				add_action( 'admin_menu', array( $this, 'addmenu' ) );
 			}
             add_action( 'admin_init', array( $this, 'registersettings' ) );
@@ -645,7 +646,8 @@ if ( function_exists( 'is_plugin_active' ) && ! is_plugin_active( 'autoptimize-c
     {
 		if ( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
 			$hook = add_submenu_page( 'settings.php',  __( 'Autoptimize Options', 'autoptimize' ), 'Autoptimize', 'manage_network_options', 'autoptimize', array( $this, 'show' ) );
-		} else {
+		} 
+		if ( 'on' === autoptimizeOption::get_option('autoptimize_enable_site_config') ) {
 			$hook = add_options_page( __( 'Autoptimize Options', 'autoptimize' ), 'Autoptimize', 'manage_options', 'autoptimize', array( $this, 'show' ) );
 		}
 		

--- a/classes/autoptimizeConfig.php
+++ b/classes/autoptimizeConfig.php
@@ -213,6 +213,19 @@ input[type=url]:invalid {color: red; border-color:red;} .form-table th{font-weig
 
 <ul>
 
+<?php if( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) { ?>
+	<li class="itemDetail">
+	<h2 class="itemTitle"><?php _e('Multisite Options','autoptimize'); ?></h2>
+	<table class="form-table">
+	<tr valign="top">
+	<th scope="row"><?php _e('Enable site configuration?','autoptimize'); ?></th>
+	<td><label class="cb_label"><input type="checkbox" id="autoptimize_enable_site_config" name="autoptimize_enable_site_config" <?php echo autoptimizeOption::get_option('autoptimize_enable_site_config')?'checked="checked" ':''; ?>/>
+	<?php _e('Enable Autoptimize configuration per site.','autoptimize'); ?></label></td>
+	</tr>
+	</table>
+	</li>
+<?php } ?>
+
 <li class="itemDetail">
 <h2 class="itemTitle"><?php _e('JavaScript Options','autoptimize'); ?></h2>
 <table class="form-table">
@@ -655,6 +668,7 @@ if ( function_exists( 'is_plugin_active' ) && ! is_plugin_active( 'autoptimize-c
     public function registersettings() {
         register_setting( 'autoptimize', 'autoptimize_html' );
         register_setting( 'autoptimize', 'autoptimize_html_keepcomments' );
+		register_setting( 'autoptimize', 'autoptimize_enable_site_config' );
         register_setting( 'autoptimize', 'autoptimize_js' );
         register_setting( 'autoptimize', 'autoptimize_js_aggregate' );
         register_setting( 'autoptimize', 'autoptimize_js_exclude' );
@@ -713,6 +727,7 @@ if ( function_exists( 'is_plugin_active' ) && ! is_plugin_active( 'autoptimize-c
         static $config = array(
             'autoptimize_html' => 0,
             'autoptimize_html_keepcomments' => 0,
+			'autoptimize_enable_site_config' => 0,
             'autoptimize_js' => 0,
             'autoptimize_js_aggregate' => 1,
             'autoptimize_js_exclude' => 'wp-includes/js/dist/, wp-includes/js/tinymce/, js/jquery/jquery.js',

--- a/classes/autoptimizeConfig.php
+++ b/classes/autoptimizeConfig.php
@@ -29,9 +29,9 @@ class autoptimizeConfig
             }
 
             // Clean cache?
-            if ( get_option( 'autoptimize_cache_clean' ) ) {
+            if ( autoptimizeOption::get_option( 'autoptimize_cache_clean' ) ) {
                 autoptimizeCache::clearall();
-                update_option( 'autoptimize_cache_clean', 0 );
+                autoptimizeOption::update_option( 'autoptimize_cache_clean', 0 );
             }
 
             $this->settings_screen_do_remote_http = apply_filters( 'autoptimize_settingsscreen_remotehttp', $this->settings_screen_do_remote_http );
@@ -188,7 +188,7 @@ input[type=url]:invalid {color: red; border-color:red;} .form-table th{font-weig
     <div id="ao_title_and_button">
         <h1 id="ao_title"><?php _e( 'Autoptimize Settings', 'autoptimize' ); ?>
         <span id="ao_adv_button">
-        <?php if ( get_option( 'autoptimize_show_adv', '1' ) == '1' ) { ?>
+        <?php if ( autoptimizeOption::get_option( 'autoptimize_show_adv', '1' ) == '1' ) { ?>
             <a href="javascript:void(0);" id="ao_show_adv" class="button" style="display:none;"><span><?php _e("Show advanced settings","autoptimize") ?></span></a>
             <a href="javascript:void(0);" id="ao_hide_adv" class="button"><span><?php _e("Hide advanced settings","autoptimize") ?></span></a>
             <style>tr.ao_adv{display:table-row;} li.ao_adv{display:list-item;}</style>
@@ -214,7 +214,7 @@ input[type=url]:invalid {color: red; border-color:red;} .form-table th{font-weig
 <table class="form-table">
 <tr valign="top">
 <th scope="row"><?php _e('Optimize JavaScript Code?','autoptimize'); ?></th>
-<td><input type="checkbox" id="autoptimize_js" name="autoptimize_js" <?php echo get_option('autoptimize_js')?'checked="checked" ':''; ?>/></td>
+<td><input type="checkbox" id="autoptimize_js" name="autoptimize_js" <?php echo autoptimizeOption::get_option('autoptimize_js')?'checked="checked" ':''; ?>/></td>
 </tr>
 <tr valign="top" class="<?php echo $hiddenClass;?>js_sub ao_adv">
 <th scope="row"><?php _e( 'Aggregate JS-files?', 'autoptimize' ); ?></th>
@@ -223,29 +223,29 @@ input[type=url]:invalid {color: red; border-color:red;} .form-table th{font-weig
 </tr>
 <tr valign="top" class="<?php echo $hiddenClass;?>js_sub ao_adv js_aggregate">
 <th scope="row"><?php _e('Also aggregate inline JS?','autoptimize'); ?></th>
-<td><label class="cb_label"><input type="checkbox" name="autoptimize_js_include_inline" <?php echo get_option('autoptimize_js_include_inline')?'checked="checked" ':''; ?>/>
+<td><label class="cb_label"><input type="checkbox" name="autoptimize_js_include_inline" <?php echo autoptimizeOption::get_option('autoptimize_js_include_inline')?'checked="checked" ':''; ?>/>
 <?php _e('Let Autoptimize also extract JS from the HTML. <strong>Warning</strong>: this can make Autoptimize\'s cache size grow quickly, so only enable this if you know what you\'re doing.','autoptimize'); ?></label></td>
 </tr>
 <tr valign="top" class="<?php echo $hiddenClass;?>js_sub ao_adv js_aggregate">
 <th scope="row"><?php _e('Force JavaScript in &lt;head&gt;?','autoptimize'); ?></th>
-<td><label class="cb_label"><input type="checkbox" name="autoptimize_js_forcehead" <?php echo get_option('autoptimize_js_forcehead')?'checked="checked" ':''; ?>/>
+<td><label class="cb_label"><input type="checkbox" name="autoptimize_js_forcehead" <?php echo autoptimizeOption::get_option('autoptimize_js_forcehead')?'checked="checked" ':''; ?>/>
 <?php _e('Load JavaScript early, this can potentially fix some JS-errors, but makes the JS render blocking.','autoptimize'); ?></label></td>
 </tr>
-<?php if (get_option('autoptimize_js_justhead')) { ?>
+<?php if (autoptimizeOption::get_option('autoptimize_js_justhead')) { ?>
 <tr valign="top" class="<?php echo $hiddenClass;?>js_sub ao_adv js_aggregate">
 <th scope="row"><?php _e('Look for scripts only in &lt;head&gt;?','autoptimize'); echo ' <i>'. __('(deprecated)','autoptimize') . '</i>'; ?></th>
-<td><label class="cb_label"><input type="checkbox" name="autoptimize_js_justhead" <?php echo get_option('autoptimize_js_justhead')?'checked="checked" ':''; ?>/>
+<td><label class="cb_label"><input type="checkbox" name="autoptimize_js_justhead" <?php echo autoptimizeOption::get_option('autoptimize_js_justhead')?'checked="checked" ':''; ?>/>
 <?php _e('Mostly useful in combination with previous option when using jQuery-based templates, but might help keeping cache size under control.','autoptimize'); ?></label></td>
 </tr>
 <?php } ?>
 <tr valign="top" class="<?php echo $hiddenClass;?>js_sub ao_adv">
 <th scope="row"><?php _e('Exclude scripts from Autoptimize:','autoptimize'); ?></th>
-<td><label><input type="text" style="width:100%;" name="autoptimize_js_exclude" value="<?php echo get_option('autoptimize_js_exclude',"wp-includes/js/dist/, wp-includes/js/tinymce/, js/jquery/jquery.js"); ?>"/><br />
+<td><label><input type="text" style="width:100%;" name="autoptimize_js_exclude" value="<?php echo autoptimizeOption::get_option('autoptimize_js_exclude',"wp-includes/js/dist/, wp-includes/js/tinymce/, js/jquery/jquery.js"); ?>"/><br />
 <?php _e('A comma-separated list of scripts you want to exclude from being optimized, for example \'whatever.js, another.js\' (without the quotes) to exclude those scripts from being aggregated by Autoptimize.','autoptimize'); ?></label></td>
 </tr>
 <tr valign="top" class="<?php echo $hiddenClass;?>js_sub ao_adv js_aggregate">
 <th scope="row"><?php _e('Add try-catch wrapping?','autoptimize'); ?></th>
-<td><label class="cb_label"><input type="checkbox" name="autoptimize_js_trycatch" <?php echo get_option('autoptimize_js_trycatch')?'checked="checked" ':''; ?>/>
+<td><label class="cb_label"><input type="checkbox" name="autoptimize_js_trycatch" <?php echo autoptimizeOption::get_option('autoptimize_js_trycatch')?'checked="checked" ':''; ?>/>
 <?php _e('If your scripts break because of a JS-error, you might want to try this.','autoptimize'); ?></label></td>
 </tr>
 </table>
@@ -256,7 +256,7 @@ input[type=url]:invalid {color: red; border-color:red;} .form-table th{font-weig
 <table class="form-table">
 <tr valign="top">
 <th scope="row"><?php _e('Optimize CSS Code?','autoptimize'); ?></th>
-<td><input type="checkbox" id="autoptimize_css" name="autoptimize_css" <?php echo get_option('autoptimize_css')?'checked="checked" ':''; ?>/></td>
+<td><input type="checkbox" id="autoptimize_css" name="autoptimize_css" <?php echo autoptimizeOption::get_option('autoptimize_css')?'checked="checked" ':''; ?>/></td>
 </tr>
 <tr class="<?php echo $hiddenClass;?>css_sub ao_adv" valign="top">
 <th scope="row"><?php _e( 'Aggregate CSS-files?', 'autoptimize' ); ?></th>
@@ -265,24 +265,24 @@ input[type=url]:invalid {color: red; border-color:red;} .form-table th{font-weig
 </tr>
 <tr valign="top" class="<?php echo $hiddenClass;?>css_sub ao_adv css_aggregate">
 <th scope="row"><?php _e('Also aggregate inline CSS?','autoptimize'); ?></th>
-<td><label class="cb_label"><input type="checkbox" name="autoptimize_css_include_inline" <?php echo get_option('autoptimize_css_include_inline','1')?'checked="checked" ':''; ?>/>
+<td><label class="cb_label"><input type="checkbox" name="autoptimize_css_include_inline" <?php echo autoptimizeOption::get_option('autoptimize_css_include_inline','1')?'checked="checked" ':''; ?>/>
 <?php _e('Check this option for Autoptimize to also aggregate CSS in the HTML.','autoptimize'); ?></label></td>
 </tr>
 <tr class="<?php echo $hiddenClass;?>css_sub ao_adv css_aggregate" valign="top">
 <th scope="row"><?php _e('Generate data: URIs for images?','autoptimize'); ?></th>
-<td><label class="cb_label"><input type="checkbox" name="autoptimize_css_datauris" <?php echo get_option('autoptimize_css_datauris')?'checked="checked" ':''; ?>/>
+<td><label class="cb_label"><input type="checkbox" name="autoptimize_css_datauris" <?php echo autoptimizeOption::get_option('autoptimize_css_datauris')?'checked="checked" ':''; ?>/>
 <?php _e('Enable this to include small background-images in the CSS itself instead of as separate downloads.','autoptimize'); ?></label></td>
 </tr>
-<?php if (get_option('autoptimize_css_justhead')) { ?>
+<?php if (autoptimizeOption::get_option('autoptimize_css_justhead')) { ?>
 <tr valign="top" class="<?php echo $hiddenClass;?>css_sub ao_adv css_aggregate">
 <th scope="row"><?php _e('Look for styles only in &lt;head&gt;?','autoptimize'); echo ' <i>'. __('(deprecated)','autoptimize') . '</i>'; ?></th>
-<td><label class="cb_label"><input type="checkbox" name="autoptimize_css_justhead" <?php echo get_option('autoptimize_css_justhead')?'checked="checked" ':''; ?>/>
+<td><label class="cb_label"><input type="checkbox" name="autoptimize_css_justhead" <?php echo autoptimizeOption::get_option('autoptimize_css_justhead')?'checked="checked" ':''; ?>/>
 <?php _e('Don\'t autoptimize CSS outside the head-section. If the cache gets big, you might want to enable this.','autoptimize'); ?></label></td>
 </tr>
 <?php } ?>
 <tr valign="top" class="<?php echo $hiddenClass;?>css_sub ao_adv">
 <th scope="row"><?php _e('Inline and Defer CSS?','autoptimize'); ?></th>
-<td><label class="cb_label"><input type="checkbox" name="autoptimize_css_defer" id="autoptimize_css_defer" <?php echo get_option('autoptimize_css_defer')?'checked="checked" ':''; ?>/>
+<td><label class="cb_label"><input type="checkbox" name="autoptimize_css_defer" id="autoptimize_css_defer" <?php echo autoptimizeOption::get_option('autoptimize_css_defer')?'checked="checked" ':''; ?>/>
 <?php
 _e( 'Inline "above the fold CSS" while loading the main autoptimized CSS only after page load. <a href="http://wordpress.org/plugins/autoptimize/faq/" target="_blank">Check the FAQ</a> for more info.', 'autoptimize' );
 if ( function_exists( 'is_plugin_active' ) && ! is_plugin_active( 'autoptimize-criticalcss/ao_criticss_aas.php' ) ) {
@@ -295,16 +295,16 @@ if ( function_exists( 'is_plugin_active' ) && ! is_plugin_active( 'autoptimize-c
 </tr>
 <tr valign="top" class="<?php echo $hiddenClass;?>css_sub ao_adv" id="autoptimize_css_defer_inline">
 <th scope="row"></th>
-<td><label><textarea rows="10" cols="10" style="width:100%;" placeholder="<?php _e('Paste the above the fold CSS here.','autoptimize'); ?>" name="autoptimize_css_defer_inline"><?php echo get_option('autoptimize_css_defer_inline'); ?></textarea></label></td>
+<td><label><textarea rows="10" cols="10" style="width:100%;" placeholder="<?php _e('Paste the above the fold CSS here.','autoptimize'); ?>" name="autoptimize_css_defer_inline"><?php echo autoptimizeOption::get_option('autoptimize_css_defer_inline'); ?></textarea></label></td>
 </tr>
 <tr valign="top" class="<?php echo $hiddenClass;?>ao_adv css_sub css_aggregate">
 <th scope="row"><?php _e('Inline all CSS?','autoptimize'); ?></th>
-<td><label class="cb_label"><input type="checkbox" id="autoptimize_css_inline" name="autoptimize_css_inline" <?php echo get_option('autoptimize_css_inline')?'checked="checked" ':''; ?>/>
+<td><label class="cb_label"><input type="checkbox" id="autoptimize_css_inline" name="autoptimize_css_inline" <?php echo autoptimizeOption::get_option('autoptimize_css_inline')?'checked="checked" ':''; ?>/>
 <?php _e('Inlining all CSS can improve performance for sites with a low pageviews/ visitor-rate, but may slow down performance otherwise.','autoptimize'); ?></label></td>
 </tr>
 <tr valign="top" class="<?php echo $hiddenClass;?>ao_adv css_sub">
 <th scope="row"><?php _e('Exclude CSS from Autoptimize:','autoptimize'); ?></th>
-<td><label><input type="text" style="width:100%;" name="autoptimize_css_exclude" value="<?php echo get_option('autoptimize_css_exclude','wp-content/cache/, wp-content/uploads/, admin-bar.min.css, dashicons.min.css'); ?>"/><br />
+<td><label><input type="text" style="width:100%;" name="autoptimize_css_exclude" value="<?php echo autoptimizeOption::get_option('autoptimize_css_exclude','wp-content/cache/, wp-content/uploads/, admin-bar.min.css, dashicons.min.css'); ?>"/><br />
 <?php _e('A comma-separated list of CSS you want to exclude from being optimized.','autoptimize'); ?></label></td>
 </tr>
 </table>
@@ -315,11 +315,11 @@ if ( function_exists( 'is_plugin_active' ) && ! is_plugin_active( 'autoptimize-c
 <table class="form-table">
 <tr valign="top">
 <th scope="row"><?php _e('Optimize HTML Code?','autoptimize'); ?></th>
-<td><input type="checkbox" id="autoptimize_html" name="autoptimize_html" <?php echo get_option('autoptimize_html')?'checked="checked" ':''; ?>/></td>
+<td><input type="checkbox" id="autoptimize_html" name="autoptimize_html" <?php echo autoptimizeOption::get_option('autoptimize_html')?'checked="checked" ':''; ?>/></td>
 </tr>
 <tr class="<?php echo $hiddenClass;?>html_sub ao_adv" valign="top">
 <th scope="row"><?php _e('Keep HTML comments?','autoptimize'); ?></th>
-<td><label class="cb_label"><input type="checkbox" name="autoptimize_html_keepcomments" <?php echo get_option('autoptimize_html_keepcomments')?'checked="checked" ':''; ?>/>
+<td><label class="cb_label"><input type="checkbox" name="autoptimize_html_keepcomments" <?php echo autoptimizeOption::get_option('autoptimize_html_keepcomments')?'checked="checked" ':''; ?>/>
 <?php _e('Enable this if you want HTML comments to remain in the page.','autoptimize'); ?></label></td>
 </tr>
 </table>
@@ -330,7 +330,7 @@ if ( function_exists( 'is_plugin_active' ) && ! is_plugin_active( 'autoptimize-c
 <table class="form-table">
 <tr valign="top">
 <th scope="row"><?php _e('CDN Base URL','autoptimize'); ?></th>
-<td><label><input id="cdn_url" type="text" name="autoptimize_cdn_url" pattern="^(https?:)?\/\/([\da-z\.-]+)\.([\da-z\.]{2,6})([\/\w \.-]*)*(:\d{2,5})?\/?$" style="width:100%" value="<?php echo esc_url(get_option('autoptimize_cdn_url',''),array("http","https")); ?>" /><br />
+<td><label><input id="cdn_url" type="text" name="autoptimize_cdn_url" pattern="^(https?:)?\/\/([\da-z\.-]+)\.([\da-z\.]{2,6})([\/\w \.-]*)*(:\d{2,5})?\/?$" style="width:100%" value="<?php echo esc_url(autoptimizeOption::get_option('autoptimize_cdn_url',''),array("http","https")); ?>" /><br />
 <?php _e('Enter your CDN root URL to enable CDN for Autoptimized files. The URL can be http, https or protocol-relative (e.g. <code>//cdn.example.com/</code>). This is not needed for Cloudflare.','autoptimize'); ?></label></td>
 </tr>
 </table>
@@ -369,7 +369,7 @@ if ( function_exists( 'is_plugin_active' ) && ! is_plugin_active( 'autoptimize-c
 <table class="form-table">
     <tr valign="top" class="<?php echo $hiddenClass;?>ao_adv">
     <th scope="row"><?php _e('Save aggregated script/css as static files?','autoptimize'); ?></th>
-    <td><label class="cb_label"><input type="checkbox" name="autoptimize_cache_nogzip" <?php echo get_option('autoptimize_cache_nogzip','1')?'checked="checked" ':''; ?>/>
+    <td><label class="cb_label"><input type="checkbox" name="autoptimize_cache_nogzip" <?php echo autoptimizeOption::get_option('autoptimize_cache_nogzip','1')?'checked="checked" ':''; ?>/>
     <?php _e('By default files saved are static css/js, uncheck this option if your webserver doesn\'t properly handle the compression and expiry.','autoptimize'); ?></label></td>
     </tr>
     <?php
@@ -380,12 +380,12 @@ if ( function_exists( 'is_plugin_active' ) && ! is_plugin_active( 'autoptimize-c
     ?>
     <tr valign="top" id="min_excl_row" class="<?php echo $hiddenClass.$_min_excl_class; ?>">
         <th scope="row"><?php _e('Minify excluded CSS and JS files?','autoptimize'); ?></th>
-        <td><label class="cb_label"><input type="checkbox" name="autoptimize_minify_excluded" <?php echo get_option('autoptimize_minify_excluded','1')?'checked="checked" ':''; ?>/>
+        <td><label class="cb_label"><input type="checkbox" name="autoptimize_minify_excluded" <?php echo autoptimizeOption::get_option('autoptimize_minify_excluded','1')?'checked="checked" ':''; ?>/>
         <?php _e('When aggregating JS or CSS, excluded files that are not minified (based on filename) are by default minified by Autoptimize despite being excluded. Uncheck this option if anything breaks despite excluding.','autoptimize'); ?></label></td>
     </tr>
     <tr valign="top" class="<?php echo $hiddenClass;?>ao_adv">
     <th scope="row"><?php _e('Also optimize for logged in users?','autoptimize'); ?></th>
-    <td><label class="cb_label"><input type="checkbox" name="autoptimize_optimize_logged" <?php echo get_option('autoptimize_optimize_logged','1')?'checked="checked" ':''; ?>/>
+    <td><label class="cb_label"><input type="checkbox" name="autoptimize_optimize_logged" <?php echo autoptimizeOption::get_option('autoptimize_optimize_logged','1')?'checked="checked" ':''; ?>/>
     <?php _e('By default Autoptimize is also active for logged on users, uncheck not to optimize when logged in e.g. to use a pagebuilder.','autoptimize'); ?></label></td>
     </tr>
     <?php
@@ -393,7 +393,7 @@ if ( function_exists( 'is_plugin_active' ) && ! is_plugin_active( 'autoptimize-c
     ?>
     <tr valign="top" class="<?php echo $hiddenClass;?>ao_adv">
         <th scope="row"><?php _e('Also optimize shop cart/ checkout?','autoptimize'); ?></th>
-        <td><label class="cb_label"><input type="checkbox" name="autoptimize_optimize_checkout" <?php echo get_option('autoptimize_optimize_checkout','1')?'checked="checked" ':''; ?>/>
+        <td><label class="cb_label"><input type="checkbox" name="autoptimize_optimize_checkout" <?php echo autoptimizeOption::get_option('autoptimize_optimize_checkout','1')?'checked="checked" ':''; ?>/>
             <?php _e('By default Autoptimize is also active on your shop\'s cart/ checkout, uncheck not to optimize those.','autoptimize'); ?></label>
         </td>
     </tr>
@@ -403,7 +403,7 @@ if ( function_exists( 'is_plugin_active' ) && ! is_plugin_active( 'autoptimize-c
 
 </ul>
 
-<input type="hidden" id="autoptimize_show_adv" name="autoptimize_show_adv" value="<?php echo get_option('autoptimize_show_adv','1'); ?>">
+<input type="hidden" id="autoptimize_show_adv" name="autoptimize_show_adv" value="<?php echo autoptimizeOption::get_option('autoptimize_show_adv','1'); ?>">
 
 <p class="submit">
 <input type="submit" class="button-secondary" value="<?php _e('Save Changes','autoptimize') ?>" />
@@ -796,7 +796,7 @@ if ( function_exists( 'is_plugin_active' ) && ! is_plugin_active( 'autoptimize-c
 
             // Override with user settings.
             foreach ( array_keys( $config ) as $name ) {
-                $conf = get_option( $name );
+                $conf = autoptimizeOption::get_option( $name );
                 if ( false !== $conf ) {
                     // It was set before!
                     $config[ $name ] = $conf;

--- a/classes/autoptimizeConfig.php
+++ b/classes/autoptimizeConfig.php
@@ -18,9 +18,8 @@ class autoptimizeConfig
 			if ( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
 				add_action( 'network_admin_menu', array( $this, 'addmenu' ) );
 			}
-			if ( ! is_multisite() || 'on' === autoptimizeOption::get_option('autoptimize_enable_site_config') ) {
-				add_action( 'admin_menu', array( $this, 'addmenu' ) );
-			}
+
+			add_action( 'admin_menu', array( $this, 'addmenu' ) );
             add_action( 'admin_init', array( $this, 'registersettings' ) );
 
             // Set meta info.
@@ -59,6 +58,13 @@ class autoptimizeConfig
 
         return self::$instance;
     }
+
+	public function show_message() {
+		?>
+			<h1>Autoptimize enabled in network</h1>
+			<p>If you want to enable per site configutation for Autoptimize, please contact your network administrator.</p>
+		<?php
+	}
 
     public function show()
     {
@@ -653,8 +659,10 @@ if ( function_exists( 'is_plugin_active' ) && ! is_plugin_active( 'autoptimize-c
 		}
 		if ( ! is_multisite() || 'on' === autoptimizeOption::get_option('autoptimize_enable_site_config') ) {
 			$hook = add_options_page( __( 'Autoptimize Options', 'autoptimize' ), 'Autoptimize', 'manage_options', 'autoptimize', array( $this, 'show' ) );
+		} else {
+			$hook = add_options_page( __( 'Autoptimize Options', 'autoptimize' ), 'Autoptimize', 'manage_options', 'autoptimize', array( $this, 'show_message' ) );
 		}
-		
+
         add_action( 'admin_print_scripts-' . $hook, array( $this, 'autoptimize_admin_scripts' ) );
         add_action( 'admin_print_styles-' . $hook, array( $this, 'autoptimize_admin_styles' ) );
     }

--- a/classes/autoptimizeConfig.php
+++ b/classes/autoptimizeConfig.php
@@ -15,7 +15,11 @@ class autoptimizeConfig
     {
         if ( is_admin() ) {
             // Add the admin page and settings.
-            add_action( 'admin_menu', array( $this, 'addmenu' ) );
+			if ( is_multisite() && is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
+				add_action( 'network_admin_menu', array( $this, 'addmenu' ) );
+			} else {
+				add_action( 'admin_menu', array( $this, 'addmenu' ) );
+			}
             add_action( 'admin_init', array( $this, 'registersettings' ) );
 
             // Set meta info.
@@ -626,7 +630,12 @@ if ( function_exists( 'is_plugin_active' ) && ! is_plugin_active( 'autoptimize-c
 
     public function addmenu()
     {
-        $hook = add_options_page( __( 'Autoptimize Options', 'autoptimize' ), 'Autoptimize', 'manage_options', 'autoptimize', array( $this, 'show' ) );
+		if ( is_multisite() && is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
+			$hook = add_submenu_page( 'settings.php',  __( 'Autoptimize Options', 'autoptimize' ), 'Autoptimize', 'manage_network_options', 'autoptimize', array( $this, 'show' ) );
+		} else {
+			$hook = add_options_page( __( 'Autoptimize Options', 'autoptimize' ), 'Autoptimize', 'manage_options', 'autoptimize', array( $this, 'show' ) );
+		}
+		
         add_action( 'admin_print_scripts-' . $hook, array( $this, 'autoptimize_admin_scripts' ) );
         add_action( 'admin_print_styles-' . $hook, array( $this, 'autoptimize_admin_styles' ) );
     }

--- a/classes/autoptimizeConfig.php
+++ b/classes/autoptimizeConfig.php
@@ -17,8 +17,8 @@ class autoptimizeConfig
             // Add the admin page and settings.
 			if ( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
 				add_action( 'network_admin_menu', array( $this, 'addmenu' ) );
-			} 
-			if ( 'on' === autoptimizeOption::get_option('autoptimize_enable_site_config') ) {
+			}
+			if ( ! is_multisite() || 'on' === autoptimizeOption::get_option('autoptimize_enable_site_config') ) {
 				add_action( 'admin_menu', array( $this, 'addmenu' ) );
 			}
             add_action( 'admin_init', array( $this, 'registersettings' ) );
@@ -650,8 +650,8 @@ if ( function_exists( 'is_plugin_active' ) && ! is_plugin_active( 'autoptimize-c
     {
 		if ( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
 			$hook = add_submenu_page( 'settings.php',  __( 'Autoptimize Options', 'autoptimize' ), 'Autoptimize', 'manage_network_options', 'autoptimize', array( $this, 'show' ) );
-		} 
-		if ( 'on' === autoptimizeOption::get_option('autoptimize_enable_site_config') ) {
+		}
+		if ( ! is_multisite() || 'on' === autoptimizeOption::get_option('autoptimize_enable_site_config') ) {
 			$hook = add_options_page( __( 'Autoptimize Options', 'autoptimize' ), 'Autoptimize', 'manage_options', 'autoptimize', array( $this, 'show' ) );
 		}
 		

--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -370,7 +370,7 @@ class autoptimizeExtra
     <div class="wrap">
     <h1><?php _e( 'Autoptimize Settings', 'autoptimize' ); ?></h1>
         <?php echo autoptimizeConfig::ao_admin_tabs(); ?>
-        <?php if ( 'on' !== get_option( 'autoptimize_js' ) && 'on' !== get_option( 'autoptimize_css' ) && 'on' !== get_option( 'autoptimize_html' ) && ! autoptimizeImages::imgopt_active() ) { ?>
+        <?php if ( 'on' !== autoptimizeOption::get_option( 'autoptimize_js' ) && 'on' !== autoptimizeOption::get_option( 'autoptimize_css' ) && 'on' !== autoptimizeOption::get_option( 'autoptimize_html' ) && ! autoptimizeImages::imgopt_active() ) { ?>
             <div class="notice-warning notice"><p>
             <?php _e( 'Most of below Extra optimizations require at least one of HTML, JS, CSS or Image autoptimizations being active.', 'autoptimize' ); ?>
             </p></div>

--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -33,7 +33,12 @@ class autoptimizeExtra
     public function run()
     {
         if ( is_admin() ) {
-            add_action( 'admin_menu', array( $this, 'admin_menu' ) );
+			if ( is_multisite() && is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
+				add_action( 'network_admin_menu', array( $this, 'admin_menu' ) );
+			} else {
+				add_action( 'admin_menu', array( $this, 'admin_menu' ) );
+			}
+			add_action( 'admin_init', array( $this, 'registersettings' ) );
             add_filter( 'autoptimize_filter_settingsscreen_tabs', array( $this, 'add_extra_tab' ) );
         } else {
             $this->run_on_frontend();
@@ -335,8 +340,11 @@ class autoptimizeExtra
             'autoptimize_extra',
             array( $this, 'options_page' )
         );
-        register_setting( 'autoptimize_extra_settings', 'autoptimize_extra_settings' );
     }
+	
+	public function registersettings() {
+		register_setting( 'autoptimize_extra_settings', 'autoptimize_extra_settings' );
+	}
 
     public function add_extra_tab( $in )
     {

--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -368,7 +368,7 @@ class autoptimizeExtra
             </p></div>
         <?php } ?>
 
-    <form id='ao_settings_form' action='options.php' method='post'>
+    <form id='ao_settings_form' action='<?php echo admin_url( 'options.php' ); ?>' method='post'>
         <?php settings_fields( 'autoptimize_extra_settings' ); ?>
         <h2><?php _e( 'Extra Auto-Optimizations', 'autoptimize' ); ?></h2>
         <span id='autoptimize_extra_descr'><?php _e( 'The following settings can improve your site\'s performance even more.', 'autoptimize' ); ?></span>

--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -33,7 +33,7 @@ class autoptimizeExtra
     public function run()
     {
         if ( is_admin() ) {
-			if ( is_multisite() && is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
+			if ( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
 				add_action( 'network_admin_menu', array( $this, 'admin_menu' ) );
 			} else {
 				add_action( 'admin_menu', array( $this, 'admin_menu' ) );

--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -42,7 +42,7 @@ class autoptimizeExtra
 
     public static function fetch_options()
     {
-        $value = get_option( 'autoptimize_extra_settings' );
+        $value = autoptimizeOption::get_option( 'autoptimize_extra_settings' );
         if ( empty( $value ) ) {
             // Fallback to returning defaults when no stored option exists yet.
             $value = autoptimizeConfig::get_ao_extra_default_options();

--- a/classes/autoptimizeImages.php
+++ b/classes/autoptimizeImages.php
@@ -97,7 +97,7 @@ class autoptimizeImages
     public function run()
     {
         if ( is_admin() ) {
-			if ( is_multisite() && is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
+			if ( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
 				add_action( 'network_admin_menu', array( $this, 'imgopt_admin_menu' ) );
 			} else {
 				add_action( 'admin_menu', array( $this, 'imgopt_admin_menu' ) );

--- a/classes/autoptimizeImages.php
+++ b/classes/autoptimizeImages.php
@@ -97,7 +97,12 @@ class autoptimizeImages
     public function run()
     {
         if ( is_admin() ) {
-            add_action( 'admin_menu', array( $this, 'imgopt_admin_menu' ) );
+			if ( is_multisite() && is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
+				add_action( 'network_admin_menu', array( $this, 'imgopt_admin_menu' ) );
+			} else {
+				add_action( 'admin_menu', array( $this, 'imgopt_admin_menu' ) );
+			}
+			add_action( 'admin_init', array( $this, 'registersettings' ) );
             add_filter( 'autoptimize_filter_settingsscreen_tabs', array( $this, 'add_imgopt_tab' ), 9 );
         } else {
             $this->run_on_frontend();
@@ -868,8 +873,11 @@ class autoptimizeImages
             'autoptimize_imgopt',
             array( $this, 'imgopt_options_page' )
         );
-        register_setting( 'autoptimize_imgopt_settings', 'autoptimize_imgopt_settings' );
     }
+	
+	public function registersettings() {
+		register_setting( 'autoptimize_imgopt_settings', 'autoptimize_imgopt_settings' );
+	}
 
     public function add_imgopt_tab( $in )
     {

--- a/classes/autoptimizeImages.php
+++ b/classes/autoptimizeImages.php
@@ -919,7 +919,7 @@ class autoptimizeImages
             ?>
             </p></div>
         <?php } ?>
-    <form id='ao_settings_form' action='options.php' method='post'>
+    <form id='ao_settings_form' action='<?php echo admin_url( 'options.php' ); ?>' method='post'>
         <?php settings_fields( 'autoptimize_imgopt_settings' ); ?>
         <h2><?php _e( 'Image optimization', 'autoptimize' ); ?></h2>
         <span id='autoptimize_imgopt_descr'><?php _e( 'Make your site significantly faster by just ticking a couple of checkboxes to optimize and lazy load your images, WebP support included!', 'autoptimize' ); ?></span>

--- a/classes/autoptimizeImages.php
+++ b/classes/autoptimizeImages.php
@@ -42,14 +42,14 @@ class autoptimizeImages
 
     public static function fetch_options()
     {
-        $value = get_option( 'autoptimize_imgopt_settings' );
+        $value = autoptimizeOption::get_option( 'autoptimize_imgopt_settings' );
         if ( empty( $value ) ) {
             // Fallback to returning defaults when no stored option exists yet.
             $value = autoptimizeConfig::get_ao_imgopt_default_options();
         }
 
         // get service availability and add it to the options-array.
-        $value['availabilities'] = get_option( 'autoptimize_service_availablity' );
+        $value['availabilities'] = autoptimizeOption::get_option( 'autoptimize_service_availablity' );
 
         if ( empty( $value['availabilities'] ) ) {
             $value['availabilities'] = autoptimizeUtils::check_service_availability( true );
@@ -66,7 +66,7 @@ class autoptimizeImages
         static $imgopt_active = null;
 
         if ( null === $imgopt_active ) {
-            $opts = get_option( 'autoptimize_imgopt_settings', '' );
+            $opts = autoptimizeOption::get_option( 'autoptimize_imgopt_settings', '' );
             if ( ! empty( $opts ) && is_array( $opts ) && array_key_exists( 'autoptimize_imgopt_checkbox_field_1', $opts ) && ! empty( $opts['autoptimize_imgopt_checkbox_field_1'] ) && '1' === $opts['autoptimize_imgopt_checkbox_field_1'] ) {
                 $imgopt_active = true;
             } else {
@@ -302,7 +302,7 @@ class autoptimizeImages
         // get CDN domain once.
         static $cdn_domain = null;
         if ( is_null( $cdn_domain ) ) {
-            $cdn_url = apply_filters( 'autoptimize_filter_base_cdnurl', get_option( 'autoptimize_cdn_url', '' ) );
+            $cdn_url = apply_filters( 'autoptimize_filter_base_cdnurl', autoptimizeOption::get_option( 'autoptimize_cdn_url', '' ) );
             if ( ! empty( $cdn_url ) ) {
                 $cdn_domain = parse_url( $cdn_url, PHP_URL_HOST );
             } else {
@@ -381,7 +381,7 @@ class autoptimizeImages
         if ( null === $cdn_url ) {
             $cdn_url = apply_filters(
                 'autoptimize_filter_base_cdnurl',
-                get_option( 'autoptimize_cdn_url', '' )
+                autoptimizeOption::get_option( 'autoptimize_cdn_url', '' )
             );
         }
 
@@ -1053,7 +1053,7 @@ class autoptimizeImages
     public function get_imgopt_status_notice() {
         if ( $this->imgopt_active() ) {
             $_imgopt_notice = '';
-            $_stat          = get_option( 'autoptimize_imgopt_provider_stat', '' );
+            $_stat          = autoptimizeOption::get_option( 'autoptimize_imgopt_provider_stat', '' );
             $_site_host     = AUTOPTIMIZE_SITE_DOMAIN;
             $_imgopt_upsell = 'https://shortpixel.com/aospai/af/GWRGFLW109483/' . $_site_host;
 
@@ -1069,7 +1069,7 @@ class autoptimizeImages
                         'refreshImgProvStats' => '1',
                     ), admin_url( 'options-general.php' ) );
                     if ( $_stat && array_key_exists( 'timestamp', $_stat ) && ! empty( $_stat['timestamp'] ) ) {
-                        $_imgopt_stats_last_run = __( 'based on status at ', 'autoptimize' ) . date_i18n( get_option( 'time_format' ), $_stat['timestamp'] );
+                        $_imgopt_stats_last_run = __( 'based on status at ', 'autoptimize' ) . date_i18n( autoptimizeOption::get_option( 'time_format' ), $_stat['timestamp'] );
                     } else {
                         $_imgopt_stats_last_run = __( 'based on previously fetched data', 'autoptimize' );
                     }
@@ -1124,7 +1124,7 @@ class autoptimizeImages
                 if ( ! is_wp_error( $response ) ) {
                     if ( '200' == wp_remote_retrieve_response_code( $response ) ) {
                         $stats = json_decode( wp_remote_retrieve_body( $response ), true );
-                        update_option( 'autoptimize_imgopt_provider_stat', $stats );
+                        autoptimizeOption::update_option( 'autoptimize_imgopt_provider_stat', $stats );
                     }
                 }
             }
@@ -1150,12 +1150,12 @@ class autoptimizeImages
         if ( null === $launch_status ) {
             $avail_imgopt  = $this->options['availabilities']['extra_imgopt'];
             $magic_number  = intval( substr( md5( parse_url( AUTOPTIMIZE_WP_SITE_URL, PHP_URL_HOST ) ), 0, 3 ), 16 );
-            $has_launched  = get_option( 'autoptimize_imgopt_launched', '' );
+            $has_launched  = autoptimizeOption::get_option( 'autoptimize_imgopt_launched', '' );
             $launch_status = false;
             if ( $has_launched || ( is_array( $avail_imgopt ) && array_key_exists( 'launch-threshold', $avail_imgopt ) && $magic_number < $avail_imgopt['launch-threshold'] ) ) {
                 $launch_status = true;
                 if ( ! $has_launched ) {
-                    update_option( 'autoptimize_imgopt_launched', 'on' );
+                    autoptimizeOption::update_option( 'autoptimize_imgopt_launched', 'on' );
                 }
             }
         }
@@ -1173,7 +1173,7 @@ class autoptimizeImages
         static $_provider_userstatus = null;
 
         if ( is_null( $_provider_userstatus ) ) {
-            $_stat = get_option( 'autoptimize_imgopt_provider_stat', '' );
+            $_stat = autoptimizeOption::get_option( 'autoptimize_imgopt_provider_stat', '' );
             if ( is_array( $_stat ) ) {
                 if ( array_key_exists( 'Status', $_stat ) ) {
                     $_provider_userstatus['Status'] = $_stat['Status'];

--- a/classes/autoptimizeMain.php
+++ b/classes/autoptimizeMain.php
@@ -81,7 +81,7 @@ class autoptimizeMain
     public function setup()
     {
         // Do we gzip in php when caching or is the webserver doing it?
-        define( 'AUTOPTIMIZE_CACHE_NOGZIP', (bool) get_option( 'autoptimize_cache_nogzip' ) );
+        define( 'AUTOPTIMIZE_CACHE_NOGZIP', (bool) autoptimizeOption::get_option( 'autoptimize_cache_nogzip' ) );
 
         // These can be overridden by specifying them in wp-config.php or such.
         if ( ! defined( 'AUTOPTIMIZE_WP_CONTENT_NAME' ) ) {
@@ -311,12 +311,12 @@ class autoptimizeMain
             }
 
             // If setting says not to optimize logged in user and user is logged in...
-            if ( 'on' !== get_option( 'autoptimize_optimize_logged', 'on' ) && is_user_logged_in() && current_user_can( 'edit_posts' ) ) {
+            if ( 'on' !== autoptimizeOption::get_option( 'autoptimize_optimize_logged', 'on' ) && is_user_logged_in() && current_user_can( 'edit_posts' ) ) {
                 $ao_noptimize = true;
             }
 
             // If setting says not to optimize cart/checkout.
-            if ( 'on' !== get_option( 'autoptimize_optimize_checkout', 'on' ) ) {
+            if ( 'on' !== autoptimizeOption::get_option( 'autoptimize_optimize_checkout', 'on' ) ) {
                 // Checking for woocommerce, easy digital downloads and wp ecommerce...
                 foreach ( array( 'is_checkout', 'is_cart', 'edd_is_checkout', 'wpsc_is_cart', 'wpsc_is_checkout' ) as $func ) {
                     if ( function_exists( $func ) && $func() ) {

--- a/classes/autoptimizeMain.php
+++ b/classes/autoptimizeMain.php
@@ -492,6 +492,7 @@ class autoptimizeMain
             'autoptimize_css_exclude',
             'autoptimize_html',
             'autoptimize_html_keepcomments',
+			'autoptimize_enable_site_config',
             'autoptimize_js',
             'autoptimize_js_aggregate',
             'autoptimize_js_exclude',

--- a/classes/autoptimizeOption.php
+++ b/classes/autoptimizeOption.php
@@ -56,5 +56,26 @@ class autoptimizeOption
 		}
     }
 
+	/**
+	 * Use the pre_update_option filter to check if the option to be saved if from autoptimize and
+	 * in that case, take care of multisite case.
+	 */
+	public static function check_multisite_on_saving_options()
+    {
+		if ( is_multisite() && is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
+			add_filter( 'pre_update_option', [$this, 'update_autoptimize_option_on_network'], 10, 3 );
+		}
+	}
+
+	public static function update_autoptimize_option_on_network( $value, $option, $old_value ) {
+		if( strpos( $option, 'autoptimize_' ) === 0 ) {
+			if ( is_multisite() && is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
+				 update_network_option( get_main_network_id(), $option, $value );
+				 // Return old value, to stop update_option logic.
+				 return $old_value;
+			}
+		}
+		return $value;
+	}
 }
 new autoptimizeOption();

--- a/classes/autoptimizeOption.php
+++ b/classes/autoptimizeOption.php
@@ -41,11 +41,18 @@ class autoptimizeOption
 		// Ensure that is_plugin_active_for_network function is declared.
 		self::maybe_include_plugin_functions();
 		
-		if ( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
+		// This is always a network setting.
+		if( 'autoptimize_enable_site_config' === $option ) {
 			return get_network_option( get_main_network_id(), $option );
-		} else {
-			return get_option( $option, $default );
 		}
+
+		// If the plugin is network activated and our per site setting is not on, use the network configuration.
+		$configuration_per_site = get_network_option( get_main_network_id(), 'autoptimize_enable_site_config' );
+		if ( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) && 'on' !== $configuration_per_site ) {
+			return get_network_option( get_main_network_id(), $option );
+		}
+			
+		return get_option( $option, $default );
     }
 
 	/**

--- a/classes/autoptimizeOption.php
+++ b/classes/autoptimizeOption.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Autoptimize options handler.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * This class takes care of the set and get of option for standalone and multisite WordPress instances.
+ */
+class autoptimizeOption
+{
+	/**
+	 * Constructor, add filter on saving options.
+	 */
+	public function __construct()
+    {
+		add_action('init', [$this, 'check_multisite_on_saving_options']);
+	}
+
+	/**
+	 * Retrieves the option in standalone and multisite instances.
+	 * 
+	 * @param string $option  Name of option to retrieve. Expected to not be SQL-escaped.
+	 * @param mixed  $default Optional. Default value to return if the option does not exist.
+	 * @return mixed Value set for the option.
+	 */
+    public static function get_option( $option, $default = false )
+    {
+		if ( is_multisite() && is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
+			return get_network_option( get_main_network_id(), $option );
+		} else {
+			return get_option( $option, $default );
+		}
+    }
+
+	/**
+	 * Saves the option in standalone and multisite instances.
+	 * 
+	 * @param string      $option   Option name. Expected to not be SQL-escaped.
+	 * @param mixed       $value    Option value. Must be serializable if non-scalar. Expected to not be SQL-escaped.
+	 * @param string|bool $autoload Optional. Whether to load the option when WordPress starts up. For existing options,
+	 *                              `$autoload` can only be updated using `update_option()` if `$value` is also changed.
+     *			                    Accepts 'yes'|true to enable or 'no'|false to disable. For non-existent options,
+     *				                the default value is 'yes'. Default null.
+     * @return bool False if value was not updated and true if value was updated.
+	 */
+    public static function update_option( $option, $value, $autoload = null )
+    {
+		if ( is_multisite() && is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
+			return update_network_option( get_main_network_id(), $option, $value );
+		} else {
+			return update_option( $option, $value, $autoload );
+		}
+    }
+
+}
+new autoptimizeOption();

--- a/classes/autoptimizeOption.php
+++ b/classes/autoptimizeOption.php
@@ -64,8 +64,9 @@ class autoptimizeOption
 		
 		// Ensure that is_plugin_active_for_network function is declared.
 		self::maybe_include_plugin_functions();
+		$blog_id = get_current_blog_id();
 		
-		if ( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
+		if ( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) && 1 === $blog_id ) {
 			return update_network_option( get_main_network_id(), $option, $value );
 		} else {
 			return update_option( $option, $value, $autoload );
@@ -80,8 +81,9 @@ class autoptimizeOption
     {
 		// Ensure that is_plugin_active_for_network function is declared.
 		self::maybe_include_plugin_functions();
+		$blog_id = get_current_blog_id();
 		
-		if ( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
+		if ( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) && 1 === $blog_id ) {
 			add_filter( 'pre_update_option', [$this, 'update_autoptimize_option_on_network'], 10, 3 );
 		}
 	}
@@ -91,8 +93,9 @@ class autoptimizeOption
 			
 			// Ensure that is_plugin_active_for_network function is declared.
 			self::maybe_include_plugin_functions();
+			$blog_id = get_current_blog_id();
 		
-			if ( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
+			if ( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) && 1 === $blog_id ) {
 				 update_network_option( get_main_network_id(), $option, $value );
 				 // Return old value, to stop update_option logic.
 				 return $old_value;

--- a/classes/autoptimizeOption.php
+++ b/classes/autoptimizeOption.php
@@ -41,7 +41,7 @@ class autoptimizeOption
 		// Ensure that is_plugin_active_for_network function is declared.
 		self::maybe_include_plugin_functions();
 		
-		if ( is_multisite() && is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
+		if ( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
 			return get_network_option( get_main_network_id(), $option );
 		} else {
 			return get_option( $option, $default );
@@ -65,7 +65,7 @@ class autoptimizeOption
 		// Ensure that is_plugin_active_for_network function is declared.
 		self::maybe_include_plugin_functions();
 		
-		if ( is_multisite() && is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
+		if ( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
 			return update_network_option( get_main_network_id(), $option, $value );
 		} else {
 			return update_option( $option, $value, $autoload );
@@ -81,7 +81,7 @@ class autoptimizeOption
 		// Ensure that is_plugin_active_for_network function is declared.
 		self::maybe_include_plugin_functions();
 		
-		if ( is_multisite() && is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
+		if ( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
 			add_filter( 'pre_update_option', [$this, 'update_autoptimize_option_on_network'], 10, 3 );
 		}
 	}
@@ -92,7 +92,7 @@ class autoptimizeOption
 			// Ensure that is_plugin_active_for_network function is declared.
 			self::maybe_include_plugin_functions();
 		
-			if ( is_multisite() && is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
+			if ( is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
 				 update_network_option( get_main_network_id(), $option, $value );
 				 // Return old value, to stop update_option logic.
 				 return $old_value;

--- a/classes/autoptimizeOption.php
+++ b/classes/autoptimizeOption.php
@@ -19,6 +19,15 @@ class autoptimizeOption
     {
 		add_action('init', [$this, 'check_multisite_on_saving_options']);
 	}
+	
+	/**
+	 * Ensure that is_plugin_active_for_network function is declared.
+	 */
+	public static function maybe_include_plugin_functions() {
+		if( ! function_exists( 'is_plugin_active_for_network' ) ) {
+			include_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+		}
+	}
 
 	/**
 	 * Retrieves the option in standalone and multisite instances.
@@ -29,6 +38,9 @@ class autoptimizeOption
 	 */
     public static function get_option( $option, $default = false )
     {
+		// Ensure that is_plugin_active_for_network function is declared.
+		self::maybe_include_plugin_functions();
+		
 		if ( is_multisite() && is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
 			return get_network_option( get_main_network_id(), $option );
 		} else {
@@ -49,6 +61,10 @@ class autoptimizeOption
 	 */
     public static function update_option( $option, $value, $autoload = null )
     {
+		
+		// Ensure that is_plugin_active_for_network function is declared.
+		self::maybe_include_plugin_functions();
+		
 		if ( is_multisite() && is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
 			return update_network_option( get_main_network_id(), $option, $value );
 		} else {
@@ -62,6 +78,9 @@ class autoptimizeOption
 	 */
 	public static function check_multisite_on_saving_options()
     {
+		// Ensure that is_plugin_active_for_network function is declared.
+		self::maybe_include_plugin_functions();
+		
 		if ( is_multisite() && is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
 			add_filter( 'pre_update_option', [$this, 'update_autoptimize_option_on_network'], 10, 3 );
 		}
@@ -69,6 +88,10 @@ class autoptimizeOption
 
 	public static function update_autoptimize_option_on_network( $value, $option, $old_value ) {
 		if( strpos( $option, 'autoptimize_' ) === 0 ) {
+			
+			// Ensure that is_plugin_active_for_network function is declared.
+			self::maybe_include_plugin_functions();
+		
 			if ( is_multisite() && is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
 				 update_network_option( get_main_network_id(), $option, $value );
 				 // Return old value, to stop update_option logic.

--- a/classes/autoptimizePartners.php
+++ b/classes/autoptimizePartners.php
@@ -20,7 +20,11 @@ class autoptimizePartners
         if ( $this->enabled() ) {
             add_filter( 'autoptimize_filter_settingsscreen_tabs', array( $this, 'add_partner_tabs' ), 10, 1 );
         }
-        add_action( 'admin_menu', array( $this, 'add_admin_menu' ) );
+		if ( is_multisite() && is_plugin_active_for_network( 'autoptimize/autoptimize.php' ) ) {
+			add_action( 'network_admin_menu', array( $this, 'add_admin_menu' ) );
+		} else {
+			add_action( 'admin_menu', array( $this, 'add_admin_menu' ) );
+		}
     }
 
     protected function enabled()

--- a/classes/autoptimizeUtils.php
+++ b/classes/autoptimizeUtils.php
@@ -314,7 +314,7 @@ class autoptimizeUtils
             if ( '200' == wp_remote_retrieve_response_code( $service_availability_resp ) ) {
                 $availabilities = json_decode( wp_remote_retrieve_body( $service_availability_resp ), true );
                 if ( is_array( $availabilities ) ) {
-                    update_option( 'autoptimize_service_availablity', $availabilities );
+                    autoptimizeOption::update_option( 'autoptimize_service_availablity', $availabilities );
                     if ( $return_result ) {
                         return $availabilities;
                     }

--- a/classes/autoptimizeVersionUpdatesHandler.php
+++ b/classes/autoptimizeVersionUpdatesHandler.php
@@ -47,7 +47,7 @@ class autoptimizeVersionUpdatesHandler
                 $major_update = true;
                 // No break, intentionally, so all upgrades are ran during a single request...
             case '2.4':
-                if ( get_option( 'autoptimize_version', 'none' ) == '2.4.2' ) {
+                if ( autoptimizeOption::get_option( 'autoptimize_version', 'none' ) == '2.4.2' ) {
                     $this->upgrade_from_2_4_2();
                 }
                 $this->upgrade_from_2_4();
@@ -69,7 +69,7 @@ class autoptimizeVersionUpdatesHandler
      */
     public static function check_installed_and_update( $target )
     {
-        $db_version = get_option( 'autoptimize_version', 'none' );
+        $db_version = autoptimizeOption::get_option( 'autoptimize_version', 'none' );
         if ( $db_version !== $target ) {
             if ( 'none' === $db_version ) {
                 add_action( 'admin_notices', 'autoptimizeMain::notice_installed' );
@@ -79,7 +79,7 @@ class autoptimizeVersionUpdatesHandler
             }
 
             // Versions differed, upgrades happened if needed, store the new version.
-            update_option( 'autoptimize_version', $target );
+            autoptimizeOption::update_option( 'autoptimize_version', $target );
         }
     }
 
@@ -103,7 +103,7 @@ class autoptimizeVersionUpdatesHandler
     private function upgrade_from_1_6()
     {
         // If user was on version 1.6.x, force advanced options to be shown by default.
-        update_option( 'autoptimize_show_adv', '1' );
+        autoptimizeOption::update_option( 'autoptimize_show_adv', '1' );
 
         // And remove old options.
         $to_delete_options = array(
@@ -128,26 +128,26 @@ class autoptimizeVersionUpdatesHandler
     private function upgrade_from_1_7()
     {
         if ( ! is_multisite() ) {
-            $css_exclude = get_option( 'autoptimize_css_exclude' );
+            $css_exclude = autoptimizeOption::get_option( 'autoptimize_css_exclude' );
             if ( empty( $css_exclude ) ) {
                 $css_exclude = 'admin-bar.min.css, dashicons.min.css';
             } elseif ( false === strpos( $css_exclude, 'dashicons.min.css' ) ) {
                 $css_exclude .= ', dashicons.min.css';
             }
-            update_option( 'autoptimize_css_exclude', $css_exclude );
+            autoptimizeOption::update_option( 'autoptimize_css_exclude', $css_exclude );
         } else {
             global $wpdb;
             $blog_ids         = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" );
             $original_blog_id = get_current_blog_id();
             foreach ( $blog_ids as $blog_id ) {
                 switch_to_blog( $blog_id );
-                $css_exclude = get_option( 'autoptimize_css_exclude' );
+                $css_exclude = autoptimizeOption::get_option( 'autoptimize_css_exclude' );
                 if ( empty( $css_exclude ) ) {
                     $css_exclude = 'admin-bar.min.css, dashicons.min.css';
                 } elseif ( false === strpos( $css_exclude, 'dashicons.min.css' ) ) {
                     $css_exclude .= ', dashicons.min.css';
                 }
-                update_option( 'autoptimize_css_exclude', $css_exclude );
+                autoptimizeOption::update_option( 'autoptimize_css_exclude', $css_exclude );
             }
             switch_to_blog( $original_blog_id );
         }
@@ -162,16 +162,16 @@ class autoptimizeVersionUpdatesHandler
     private function upgrade_from_1_9()
     {
         if ( ! is_multisite() ) {
-            update_option( 'autoptimize_css_include_inline', 'on' );
-            update_option( 'autoptimize_js_include_inline', 'on' );
+            autoptimizeOption::update_option( 'autoptimize_css_include_inline', 'on' );
+            autoptimizeOption::update_option( 'autoptimize_js_include_inline', 'on' );
         } else {
             global $wpdb;
             $blog_ids         = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" );
             $original_blog_id = get_current_blog_id();
             foreach ( $blog_ids as $blog_id ) {
                 switch_to_blog( $blog_id );
-                update_option( 'autoptimize_css_include_inline', 'on' );
-                update_option( 'autoptimize_js_include_inline', 'on' );
+                autoptimizeOption::update_option( 'autoptimize_css_include_inline', 'on' );
+                autoptimizeOption::update_option( 'autoptimize_js_include_inline', 'on' );
             }
             switch_to_blog( $original_blog_id );
         }
@@ -203,10 +203,10 @@ class autoptimizeVersionUpdatesHandler
      */
     private function do_2_2_settings_update()
     {
-        $nogooglefont    = get_option( 'autoptimize_css_nogooglefont', '' );
-        $ao_extrasetting = get_option( 'autoptimize_extra_settings', '' );
+        $nogooglefont    = autoptimizeOption::get_option( 'autoptimize_css_nogooglefont', '' );
+        $ao_extrasetting = autoptimizeOption::get_option( 'autoptimize_extra_settings', '' );
         if ( ( $nogooglefont ) && ( empty( $ao_extrasetting ) ) ) {
-            update_option( 'autoptimize_extra_settings', autoptimizeConfig::get_ao_extra_default_options() );
+            autoptimizeOption::update_option( 'autoptimize_extra_settings', autoptimizeConfig::get_ao_extra_default_options() );
         }
         delete_option( 'autoptimize_css_nogooglefont' );
     }
@@ -236,8 +236,8 @@ class autoptimizeVersionUpdatesHandler
      * Migrate imgopt options from autoptimize_extra_settings to autoptimize_imgopt_settings
      */
     private function upgrade_from_2_4() {
-        $extra_settings  = get_option( 'autoptimize_extra_settings', '' );
-        $imgopt_settings = get_option( 'autoptimize_imgopt_settings', '' );
+        $extra_settings  = autoptimizeOption::get_option( 'autoptimize_extra_settings', '' );
+        $imgopt_settings = autoptimizeOption::get_option( 'autoptimize_imgopt_settings', '' );
         if ( empty( $imgopt_settings ) && ! empty( $extra_settings ) ) {
             $imgopt_settings = autoptimizeConfig::get_ao_imgopt_default_options();
             if ( array_key_exists( 'autoptimize_extra_checkbox_field_5', $extra_settings ) ) {
@@ -246,7 +246,7 @@ class autoptimizeVersionUpdatesHandler
             if ( array_key_exists( 'autoptimize_extra_select_field_6', $extra_settings ) ) {
                 $imgopt_settings['autoptimize_imgopt_select_field_2'] = $extra_settings['autoptimize_extra_select_field_6'];
             }
-            update_option( 'autoptimize_imgopt_settings', $imgopt_settings );
+            autoptimizeOption::update_option( 'autoptimize_imgopt_settings', $imgopt_settings );
         }
     }
 }


### PR DESCRIPTION
Hello,

This is Juanfran Granados from [Mirai](https://www.mirai.com/), an hotelier agency. This month we were evaluating your terrific plugin to handle static resources optimization, and we found out that your plugin does not have a global configuration for WordPress Multisite:

https://wordpress.org/support/topic/globally-configure-for-multisite/

Yes, you can copy the configuration to each site, but that solution does not cover a change in configuration in the future.

I addressed this problem modifying your code to use a wrapper for get_option and update_option. Inside of that wrapper, I took care of the standalone and multisite cases. I tought it is a cleaner option than adding if/else clauses in each get_option and update_option of your code. Feel free to reformulate it.

Also, I've filtered the update_option logic using pre_update_option hook to check if it's a multisite instance. I was forced to do that because you are using the Settings API to save your admin form and I didn't find a way to create a clean separate logic for Multisite.

Thanks!