### PR TITLE
Add filters for lazyload class and lazyload script

### DIFF
--- a/classes/autoptimizeImages.php
+++ b/classes/autoptimizeImages.php
@@ -748,7 +748,7 @@ class autoptimizeImages
         // Adds lazyload CSS & JS to footer, using echo because wp_enqueue_script seems not to support pushing attributes (async).
         echo apply_filters( 'autoptimize_filter_imgopt_lazyload_cssoutput', '<style>.lazyload,.lazyloading{opacity:0;}.lazyloaded{opacity:1;transition:opacity 300ms;}</style><noscript><style>.lazyload{display:none;}</style></noscript>' );
         echo apply_filters( 'autoptimize_filter_imgopt_lazyload_jsconfig', '<script' . $noptimize_flag . '>window.lazySizesConfig=window.lazySizesConfig||{};window.lazySizesConfig.loadMode=1;</script>' );
-        echo '<script async' . $noptimize_flag . ' src=\'' . plugins_url( 'external/js/lazysizes.min.js', __FILE__ ) . '\'></script>';
+        echo apply_filters( 'autoptimize_filter_imgopt_lazyload_js', '<script async' . $noptimize_flag . ' src=\'' . plugins_url( 'external/js/lazysizes.min.js', __FILE__ ) . '\'></script>' );
 
         // And add webp detection and loading JS.
         if ( $this->should_webp() ) {

--- a/classes/autoptimizeImages.php
+++ b/classes/autoptimizeImages.php
@@ -701,8 +701,10 @@ class autoptimizeImages
             // store original tag for use in noscript version.
             $noscript_tag = '<noscript>' . $tag . '</noscript>';
 
+            $lazyload_class = apply_filters( 'autoptimize_filter_imgopt_lazyload_class', 'lazyload' );
+
             // insert lazyload class.
-            $tag = $this->inject_classes_in_tag( $tag, 'lazyload ' );
+            $tag = $this->inject_classes_in_tag( $tag, "$lazyload_class " );
 
             if ( ! $placeholder || empty( $placeholder ) ) {
                 // get image width & heigth for placeholder fun (and to prevent content reflow).


### PR DESCRIPTION
Hi there,

Thank you for making Autoptimize. It's an amazing tool for both website owners and developers.

This PR does two things:

1. Add a `autoptimize_filter_imgopt_lazyload_class` filter that allows me to change the `lazyload` class added to image tags.
2. Add a `autoptimize_filter_imgopt_lazyload_js` filter that allows me to modify (or remove) the script tag used to include `lazysizes.min.js` in the footer.

I'm using a theme that already includes some lazy loading capabilities, but the feature can't be used with all images in the website.

Autoptimize lazy loading feature, on the other hand, works great for all images, even the ones that were originally lazy loaded by the theme (once I disable the theme's version of the feature).

The only downside for me is that it adds another request to download the lazysizes.min.js script or slightly increases the size of the concatenated JS files. The script is really small so that normally wouldn't be a problem, but we are already having issues with the amount of CSS/JS being included.

Since my theme doesn't let me remove the scripts they use for lazy loading (at least not in an easy to maintain way), I'm trying to take advantage of Autoptimize ability to rewrite image tags to be lazy loaded but continue using the theme scripts to take care of the loading part on the frontend.

I hope you find those two filters useful for the general community as well and can be included in a future version of the plugin. 