### PR TITLE
fix replacing image tags when using lazy loading

### DIFF
--- a/classes/autoptimizeImages.php
+++ b/classes/autoptimizeImages.php
@@ -722,8 +722,9 @@ class autoptimizeImages
                 // see https://css-tricks.com/preventing-content-reflow-from-lazy-loaded-images/ for great read on why we're using empty svg's.
                 $placeholder = apply_filters( 'autoptimize_filter_imgopt_lazyload_placeholder', $this->get_default_lazyload_placeholder( $width, $height ) );
             }
-            $tag = str_replace( ' src=', ' src=\'' . $placeholder . '\' data-src=', $tag );
-            $tag = str_replace( ' srcset=', ' data-srcset=', $tag );
+
+            $tag = preg_replace( '/(\s)src=/', ' src=\'' . $placeholder . '\' data-src=', $tag );
+            $tag = preg_replace( '/(\s)srcset=/', ' data-srcset=', $tag );
 
             // move sizes to data-sizes unless filter says no.
             if ( apply_filters( 'autoptimize_filter_imgopt_lazyload_move_sizes', true ) ) {
@@ -787,7 +788,7 @@ class autoptimizeImages
         if ( strpos( $tag, 'class=' ) !== false ) {
             $tag = preg_replace( '/(\sclass\s?=\s?("|\'))/', '$1' . $target_class, $tag );
         } else {
-            $tag = str_replace( '<img ', '<img class="' . trim( $target_class ) . '" ', $tag );
+            $tag = preg_replace( '/<img(\s)/', '<img class="' . trim( $target_class ) . '" ', $tag );
         }
 
         return $tag;


### PR DESCRIPTION
the simple `str_replace` function used before did not cover cases where other whitespace than a blank was used e.g. a newline.