### PR TITLE
Fixed the notice when status is null in php 7.4

### DIFF
--- a/classes/autoptimizeImages.php
+++ b/classes/autoptimizeImages.php
@@ -175,7 +175,7 @@ class autoptimizeImages
 
         $do_cdn      = true;
         $_userstatus = $this->get_imgopt_provider_userstatus();
-        if ( -2 == $_userstatus['Status'] ) {
+        if (isset($_userstatus['Status']) && -2 == $_userstatus['Status'] ) {
             $do_cdn = false;
         }
 


### PR DESCRIPTION
Notice: Trying to access array offset on value of type null in wp-content/plugins/autoptimize/classes/autoptimizeImages.php on line 178
Skip to content
