### PR TITLE
Allow third-party plugins to hook in and update autoptimize url

### DIFF
--- a/classes/autoptimizeCache.php
+++ b/classes/autoptimizeCache.php
@@ -142,9 +142,9 @@ class autoptimizeCache
         // The original idea here was to provide 3rd party code a hook so that
         // it can "listen" to all the complete autoptimized-urls that the page
         // will emit... Or something to that effect I think?
-        apply_filters( 'autoptimize_filter_cache_getname', AUTOPTIMIZE_CACHE_URL . $this->filename );
-
-        return $this->filename;
+        
+        // allows third party plugins to hook in and change the autoptimize url
+        return  apply_filters( 'autoptimize_filter_cache_getname', AUTOPTIMIZE_CACHE_URL . $this->filename );;
     }
 
     /**


### PR DESCRIPTION
This commit allows third party plugins to provide an updated/altered/modified versions of autoptimize files to hook in.