### PR TITLE
Add .min to the autoptimized file name extension

### DIFF
--- a/classes/autoptimizeCache.php
+++ b/classes/autoptimizeCache.php
@@ -40,15 +40,20 @@ class autoptimizeCache
      */
     public function __construct( $md5, $ext = 'php' )
     {
+        $_min_ext = '';
+        if ( apply_filters( 'autoptimize_filter_cache_url_add_min_ext', false ) ) {
+            $_min_ext = '.min';
+        }
+
         $this->cachedir = AUTOPTIMIZE_CACHE_DIR;
         $this->nogzip   = AUTOPTIMIZE_CACHE_NOGZIP;
         if ( ! $this->nogzip ) {
-            $this->filename = AUTOPTIMIZE_CACHEFILE_PREFIX . $md5 . '.min.php';
+            $this->filename = AUTOPTIMIZE_CACHEFILE_PREFIX . $md5 . $_min_ext . '.php';
         } else {
             if ( in_array( $ext, array( 'js', 'css' ) ) ) {
-                $this->filename = $ext . '/' . AUTOPTIMIZE_CACHEFILE_PREFIX . $md5 . '.min.' . $ext;
+                $this->filename = $ext . '/' . AUTOPTIMIZE_CACHEFILE_PREFIX . $md5 . $_min_ext . '.' . $ext;
             } else {
-                $this->filename = AUTOPTIMIZE_CACHEFILE_PREFIX . $md5 . '.min.' . $ext;
+                $this->filename = AUTOPTIMIZE_CACHEFILE_PREFIX . $md5 . $_min_ext . '.' . $ext;
             }
         }
     }

--- a/classes/autoptimizeCache.php
+++ b/classes/autoptimizeCache.php
@@ -43,12 +43,12 @@ class autoptimizeCache
         $this->cachedir = AUTOPTIMIZE_CACHE_DIR;
         $this->nogzip   = AUTOPTIMIZE_CACHE_NOGZIP;
         if ( ! $this->nogzip ) {
-            $this->filename = AUTOPTIMIZE_CACHEFILE_PREFIX . $md5 . '.php';
+            $this->filename = AUTOPTIMIZE_CACHEFILE_PREFIX . $md5 . '.min.php';
         } else {
             if ( in_array( $ext, array( 'js', 'css' ) ) ) {
-                $this->filename = $ext . '/' . AUTOPTIMIZE_CACHEFILE_PREFIX . $md5 . '.' . $ext;
+                $this->filename = $ext . '/' . AUTOPTIMIZE_CACHEFILE_PREFIX . $md5 . '.min.' . $ext;
             } else {
-                $this->filename = AUTOPTIMIZE_CACHEFILE_PREFIX . $md5 . '.' . $ext;
+                $this->filename = AUTOPTIMIZE_CACHEFILE_PREFIX . $md5 . '.min.' . $ext;
             }
         }
     }


### PR DESCRIPTION
By adding '.min' to the cache file extension, other minifiers will not try to minify the code again.

This fixes issue #294