### PR TITLE
Do not create empty minified css/js cache files.

### DIFF
--- a/classes/autoptimizeStyles.php
+++ b/classes/autoptimizeStyles.php
@@ -354,7 +354,7 @@ class autoptimizeStyles extends autoptimizeBase
                         $new_tag = $this->optionally_defer_excluded( $new_tag, $url );
 
                         // And replace!
-                        if ( '' !== $tag && $new_tag !== $tag ) {
+                        if ( $new_tag !== $tag ) {
                             $this->content = str_replace( $tag, $new_tag, $this->content );
                         }
                     }

--- a/classes/autoptimizeStyles.php
+++ b/classes/autoptimizeStyles.php
@@ -388,6 +388,7 @@ class autoptimizeStyles extends autoptimizeBase
                 "this.onload=null;this.rel='stylesheet'",
                 $url
             );
+            
             // Adapt original <link> element for CSS to be preloaded and add <noscript>-version for fallback.
             $new_tag = '<noscript>' . autoptimizeUtils::remove_id_from_node( $tag ) . '</noscript>' . str_replace(
                 array(
@@ -397,11 +398,12 @@ class autoptimizeStyles extends autoptimizeBase
                 "rel='preload' as='style' onload=\"" . $_preload_onload . '"',
                 $tag
             );
-        } else {
-            $new_tag = $tag;
+            
+            return $new_tag;
         }
-
-        return $new_tag;
+        
+        // Return unchanged $tag.
+        return $tag;
     }
 
     /**

--- a/classes/autoptimizeStyles.php
+++ b/classes/autoptimizeStyles.php
@@ -356,7 +356,7 @@ class autoptimizeStyles extends autoptimizeBase
                         }
 
                         // And replace!
-                        if ( $new_tag !== $tag ) {
+                        if ( ( '' !== $new_tag && $new_tag !== $tag ) || ( '' === $new_tag && apply_filters( 'autoptimize_filter_css_remove_empty_files', false ) ) ) {
                             $this->content = str_replace( $tag, $new_tag, $this->content );
                         }
                     }

--- a/classes/autoptimizeStyles.php
+++ b/classes/autoptimizeStyles.php
@@ -350,8 +350,10 @@ class autoptimizeStyles extends autoptimizeBase
                             }
                         }
 
-                        // Optionally defer (preload) non-aggregated CSS.
-                        $new_tag = $this->optionally_defer_excluded( $new_tag, $url );
+                        if ( '' !== $new_tag) {
+                            // Optionally defer (preload) non-aggregated CSS.
+                            $new_tag = $this->optionally_defer_excluded( $new_tag, $url );
+                        }
 
                         // And replace!
                         if ( $new_tag !== $tag ) {

--- a/classes/autoptimizeStyles.php
+++ b/classes/autoptimizeStyles.php
@@ -381,7 +381,7 @@ class autoptimizeStyles extends autoptimizeBase
     private function optionally_defer_excluded( $tag, $url = '' )
     {
         // Defer single CSS if "inline & defer" is ON and there is inline CSS.
-        if ( $this->defer && ! empty( $this->defer_inline ) ) {
+        if ( ! empty( $tag ) && $this->defer && ! empty( $this->defer_inline ) ) {
             // Get/ set (via filter) the JS to be triggers onload of the preloaded CSS.
             $_preload_onload = apply_filters(
                 'autoptimize_filter_css_preload_onload',

--- a/classes/autoptimizeStyles.php
+++ b/classes/autoptimizeStyles.php
@@ -343,6 +343,9 @@ class autoptimizeStyles extends autoptimizeBase
                                 if ( ! empty( $minified_url ) ) {
                                     // Replace orig URL with cached minified URL.
                                     $new_tag = str_replace( $url, $minified_url, $tag );
+                                } else {
+                                    // Remove the original style tag, because cache content is empty.
+                                    $new_tag = '';
                                 }
                             }
                         }
@@ -351,7 +354,7 @@ class autoptimizeStyles extends autoptimizeBase
                         $new_tag = $this->optionally_defer_excluded( $new_tag, $url );
 
                         // And replace!
-                        if ( '' !== $new_tag && $new_tag !== $tag ) {
+                        if ( '' !== $tag && $new_tag !== $tag ) {
                             $this->content = str_replace( $tag, $new_tag, $this->content );
                         }
                     }
@@ -933,6 +936,8 @@ class autoptimizeStyles extends autoptimizeBase
     {
         // CSS cache.
         foreach ( $this->csscode as $media => $code ) {
+            if ( empty( $code ) ) continue;
+            
             $md5   = $this->hashmap[ md5( $code ) ];
             $cache = new autoptimizeCache( $md5, 'css' );
             if ( ! $cache->check() ) {
@@ -1210,6 +1215,12 @@ class autoptimizeStyles extends autoptimizeBase
             // Now minify...
             $cssmin   = new autoptimizeCSSmin();
             $contents = trim( $cssmin->run( $contents ) );
+            
+            // Check if minified cache content is empty.
+            if ( empty( $contents ) ) {
+                return false;
+            }
+            
             // Store in cache.
             $cache->cache( $contents, 'text/css' );
         }


### PR DESCRIPTION
This fixes issue #293 

Removes also style tags from empty cache files.
This apply's for example to CSS / JS files that have only comments and no active code (yet) insight. These files can belong to a WordPress theme, so you can or do not want to delete them.