### PR TITLE
Optimize get_page_templates calls

### DIFF
--- a/classes/autoptimizeCriticalCSSCore.php
+++ b/classes/autoptimizeCriticalCSSCore.php
@@ -55,7 +55,7 @@ class autoptimizeCriticalCSSCore {
             add_action( apply_filters( 'autoptimize_filter_ccss_extend_types_hook', 'init' ), array( $this, 'ao_ccss_extend_types' ) );
 
             // When autoptimize cache is cleared, also clear transient cache for page templates
-            add_action( 'autoptimize_action_cachepurged', array('autoptimizeCriticalCSSCore', 'ao_ccss_clear_page_tpl_cache'), 10, 0 );
+            add_action( 'autoptimize_action_cachepurged', array( 'autoptimizeCriticalCSSCore', 'ao_ccss_clear_page_tpl_cache' ), 10, 0 );
         }
     }
 
@@ -207,10 +207,10 @@ class autoptimizeCriticalCSSCore {
 
         // Templates.
         // Transient cache to avoid frequent disk reads
-        $templates = get_transient('ao_ccss_page_tpls');
+        $templates = get_transient( 'autoptimize_ccss_page_templates' );
         if(!$templates) {
             $templates = wp_get_theme()->get_page_templates();
-            set_transient('ao_ccss_page_tpls', $templates, HOUR_IN_SECONDS);
+            set_transient( 'autoptimize_ccss_page_templates', $templates, HOUR_IN_SECONDS );
         }
         foreach ( $templates as $tplfile => $tplname ) {
             array_unshift( $ao_ccss_types, 'template_' . $tplfile );
@@ -600,7 +600,7 @@ class autoptimizeCriticalCSSCore {
 
     // Clears transient cache for page templates
     public static function ao_ccss_clear_page_tpl_cache() {
-        delete_transient( 'ao_ccss_page_tpls' );
+        delete_transient( 'autoptimize_ccss_page_templates' );
     }
 
 }

--- a/classes/autoptimizeCriticalCSSCore.php
+++ b/classes/autoptimizeCriticalCSSCore.php
@@ -53,6 +53,9 @@ class autoptimizeCriticalCSSCore {
 
             // Extend conditional tags on plugin initalization.
             add_action( apply_filters( 'autoptimize_filter_ccss_extend_types_hook', 'init' ), array( $this, 'ao_ccss_extend_types' ) );
+
+            // When autoptimize cache is cleared, also clear transient cache for page templates
+            add_action( 'autoptimize_action_cachepurged', array('autoptimizeCriticalCSSCore', 'ao_ccss_clear_page_tpl_cache'), 10, 0 );
         }
     }
 
@@ -203,7 +206,12 @@ class autoptimizeCriticalCSSCore {
         }
 
         // Templates.
-        $templates = wp_get_theme()->get_page_templates();
+        // Transient cache to avoid frequent disk reads
+        $templates = get_transient('ao_ccss_page_tpls');
+        if(!$templates) {
+            $templates = wp_get_theme()->get_page_templates();
+            set_transient('ao_ccss_page_tpls', $templates, HOUR_IN_SECONDS);
+        }
         foreach ( $templates as $tplfile => $tplname ) {
             array_unshift( $ao_ccss_types, 'template_' . $tplfile );
         }
@@ -589,4 +597,10 @@ class autoptimizeCriticalCSSCore {
             error_log( $message, 3, AO_CCSS_LOG );
         }
     }
+
+    // Clears transient cache for page templates
+    public static function ao_ccss_clear_page_tpl_cache() {
+        delete_transient( 'ao_ccss_page_tpls' );
+    }
+
 }


### PR DESCRIPTION
Prevent frequent disk reads by using transient cache for get_page_templates.

Original issue with more details at: https://wordpress.org/support/topic/get_page_templates-consumes-too-much-io-for-each-page-request/