### PR TITLE
fix Safari issue with supportsWebP

### DIFF
--- a/classes/autoptimizeImages.php
+++ b/classes/autoptimizeImages.php
@@ -804,7 +804,7 @@ class autoptimizeImages
         // And add webp detection and loading JS.
         if ( $this->should_webp() ) {
             $_webp_detect = "function c_webp(A){var n=new Image;n.onload=function(){var e=0<n.width&&0<n.height;A(e)},n.onerror=function(){A(!1)},n.src='data:image/webp;base64,UklGRhoAAABXRUJQVlA4TA0AAAAvAAAAEAcQERGIiP4HAA=='}function s_webp(e){window.supportsWebP=e}c_webp(s_webp);";
-            $_webp_load   = "document.addEventListener('lazybeforeunveil',function({target:c}){supportsWebP&&['data-src','data-srcset'].forEach(function(a){attr=c.getAttribute(a),null!==attr&&c.setAttribute(a,attr.replace(/\/client\//,'/client/to_webp,'))})});";
+            $_webp_load   = "document.addEventListener('lazybeforeunveil',function({target:c}){window.supportsWebP&&['data-src','data-srcset'].forEach(function(a){attr=c.getAttribute(a),null!==attr&&c.setAttribute(a,attr.replace(/\/client\//,'/client/to_webp,'))})});";
             echo apply_filters( 'autoptimize_filter_imgopt_webp_js', '<script' . $type_js . $noptimize_flag . '>' . $_webp_detect . $_webp_load . '</script>' );
         }
     }


### PR DESCRIPTION
This PR solves this:
https://wordpress.org/support/topic/supportswebp-check-does-not-work-well-with-iphones/#post-13022624

In short -
with IPhone+Safari, if you try to reference `supportsWebP` instead of `window.supportsWebP` - you get this error:

> ReferenceError: Can’t find variable: supportsWebP

