### PR TITLE
Add AMP mobile redirection script to list of JS scripts not to be moved

### DIFF
--- a/classes/autoptimizeScripts.php
+++ b/classes/autoptimizeScripts.php
@@ -59,6 +59,7 @@ class autoptimizeScripts extends autoptimizeBase
         'post_id',
         'data-noptimize',
         'logHuman',
+        'amp-mobile-version-switcher',
     );
 
     /**


### PR DESCRIPTION
Hello, I'm from the engineering team for the AMP plugin.

The AMP plugin has a feature to redirect mobile visitors to the AMP version of a page. One way we do this is by adding an inline JS script to the document `<head>`, which stops the page from loading before redirection happens. To prevent your plugin from possibly moving our JS script outside of the `<head>`, I would like to add an identifier for our script to the list of scripts that should not be moved.