### PR TITLE
Update is_amp_markup() method to first short-circuit if the page was initially AMP

### DIFF
--- a/classes/autoptimizeMain.php
+++ b/classes/autoptimizeMain.php
@@ -430,14 +430,29 @@ class autoptimizeMain
      */
     public static function is_amp_markup( $content )
     {
-        // Short-circuit when a function is available to determine whether the response is (or will be) an AMP page.
-        if ( function_exists( 'is_amp_endpoint' ) ) {
-            return is_amp_endpoint();
+        // Short-circuit if the page is already AMP from the start.
+        if (
+            preg_match(
+                sprintf(
+                    '#^(?:<!.*?>|\s+)*+<html(?=\s)[^>]*?\s(%1$s|%2$s|%3$s)(\s|=|>)#is',
+                    'amp',
+                    "\xE2\x9A\xA1", // From \AmpProject\Attribute::AMP_EMOJI.
+                    "\xE2\x9A\xA1\xEF\xB8\x8F" // From \AmpProject\Attribute::AMP_EMOJI_ALT, per https://github.com/ampproject/amphtml/issues/25990.
+                ),
+                $content
+            )
+        ) {
+            return true;
         }
 
-        $is_amp_markup = preg_match( '/<html[^>]*(?:amp|⚡)/i', $content );
+        // Or else short-circuit if the AMP plugin will be processing the output to be an AMP page.
+        if ( function_exists( 'amp_is_request' ) ) {
+            return amp_is_request(); // For AMP plugin v2.0+.
+        } elseif ( function_exists( 'is_amp_endpoint' ) ) {
+            return is_amp_endpoint(); // For older/other AMP plugins (still supported in 2.0 as an alias).
+        }
 
-        return (bool) $is_amp_markup;
+        return false;
     }
 
     /**


### PR DESCRIPTION
This is a follow-up on https://github.com/futtta/autoptimize/pull/223 which also fixes compatibility with the Web Stories plugin, which generates AMP pages containing `<amp-story>` elements. Fixes https://github.com/google/web-stories-wp/issues/3225.

The Web Stories plugin serves AMP pages natively from the start, without any processing needed by the AMP plugin. Therefore, calling `is_amp_endpoint()` is not relevant for such pages to determine whether they are AMP pages (since they already are).

The regular expression logic here comes from https://github.com/ampproject/amp-wp/pull/5316.

Otherwise, if the output-buffered page is not initially an AMP HTML page, then the `is_amp_markup()` method falls back to checking `is_amp_endpoint()` to determine if the AMP plugin _will_ make the HTML response into an AMP page. This logic here is updated to first check `amp_is_request()` which is the new preferred function to call in AMP plugin v2.0 via https://github.com/ampproject/amp-wp/pull/5218 since it has an `amp_` prefix (although the old function name is still supported as an alias).