### PR TITLE
Added support for Rapid Cache

### DIFF
--- a/classes/autoptimizeCache.php
+++ b/classes/autoptimizeCache.php
@@ -761,6 +761,8 @@ class autoptimizeCache
             w3tc_pgcache_flush();
         } elseif ( function_exists( 'wp_fast_cache_bulk_delete_all' ) ) {
             wp_fast_cache_bulk_delete_all();
+        } elseif ( function_exists( 'rapidcache_clear_cache' ) ) {
+            rapidcache_clear_cache();
         } elseif ( class_exists( 'Swift_Performance_Cache' ) ) {
             Swift_Performance_Cache::clear_all_cache();
         } elseif ( class_exists( 'WpFastestCache' ) ) {


### PR DESCRIPTION
- Make Autoptimize invoke Rapid Cache's [rapidcache_cache_clear()](https://github.com/megaoptim/rapid-cache/blob/cf5668e958abad67a111f758eea50c36659bd46a/includes/utils/helpers.php#L63) when the Autoptimize cache is cleared to clear the Rapid Cache as well.