### PR TITLE
Travis configs and compat code for PHP8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 dist: bionic
-sudo: false
 
 notifications:
   email:
@@ -17,22 +16,27 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  - 8.1.0
 
 env:
-  - WP_VERSION=latest WP_MULTISITE=0 CUSTOM_CONSTANTS=0
-
-matrix:
-  include:
-    - php: 7.3
-      env: WP_VERSION=latest WP_MULTISITE=1 CUSTOM_CONSTANTS=1
-    - php: 7.3
-      env: WP_VERSION=latest WP_MULTISITE=0 CUSTOM_CONSTANTS=1
+  global:
+    - WP_VERSION=latest
+  jobs:
+    - CUSTOM_CONSTANTS=0 WP_MULTISITE=0
+    - CUSTOM_CONSTANTS=1
+    - WP_MULTISITE=1
+    - CUSTOM_CONSTANTS=1 WP_MULTISITE=1
 
 install:
     # flags to pass to install
-    - flags="--ansi --prefer-dist --no-interaction --optimize-autoloader --no-progress"
-    # install dependencies using system provided composer binary
-    - composer install $flags
+  - flags="--ansi --prefer-dist --no-interaction --optimize-autoloader --no-progress"
+
+  # php 8.1.0 compat
+  - if [ "$TRAVIS_PHP_VERSION" == "8.1.0" ]; then rm composer.lock; fi
+  - if [ "$TRAVIS_PHP_VERSION" == "8.1.0" ]; then composer require --no-interaction --dev phpunit/phpunit:9.3; fi
+
+  # install dependencies using system provided composer binary
+  - composer install $flags
 
 before_script:
   # install wp tests infra

--- a/classes/autoptimizeBase.php
+++ b/classes/autoptimizeBase.php
@@ -77,6 +77,10 @@ abstract class autoptimizeBase
     {
         $url = apply_filters( 'autoptimize_filter_cssjs_alter_url', $url );
 
+        if ( is_null( $url ) ) {
+            return false;
+        }
+
         if ( false !== strpos( $url, '%' ) ) {
             $url = urldecode( $url );
         }

--- a/classes/external/php/jsmin.php
+++ b/classes/external/php/jsmin.php
@@ -332,7 +332,7 @@ class JSMin {
                 $c = $this->input[$this->inputIndex];
                 $this->inputIndex += 1;
             } else {
-                $c = null;
+                return $c;
             }
         }
         if (ord($c) >= self::ORD_SPACE || $c === "\n" || $c === null) {

--- a/tests/test-ao.php
+++ b/tests/test-ao.php
@@ -105,7 +105,7 @@ class AOTest extends WP_UnitTestcase
     /**
      * Runs before each test method.
      */
-    public function setUp()
+    public function setUp() : void
     {
         $this->ao = new autoptimizeMain( AUTOPTIMIZE_PLUGIN_VERSION, AUTOPTIMIZE_PLUGIN_FILE );
 
@@ -115,7 +115,7 @@ class AOTest extends WP_UnitTestcase
     /**
      * Runs after each test method.
      */
-    public function tearDown()
+    public function tearDown() : void
     {
         // Making sure certain filters are removed after each test to ensure isolation.
         $filter_tags = array(
@@ -2013,15 +2013,15 @@ HTML;
         $url = $styles->minify_single( $pathname, $cache_miss = true );
 
         // Minified url filename + its pointed to cdn.
-        $this->assertContains( AUTOPTIMIZE_CACHE_CHILD_DIR, $url );
-        $this->assertContains( '/autoptimize_single_', $url );
-        $this->assertContains( $styles->cdn_url, $url );
+        $this->assertStringContainsString( AUTOPTIMIZE_CACHE_CHILD_DIR, $url );
+        $this->assertStringContainsString( '/autoptimize_single_', $url );
+        $this->assertStringContainsString( $styles->cdn_url, $url );
 
         // Actual minified css contents are minified and cdn-ed.
         $path     = $styles->getpath( $url );
         $contents = file_get_contents( $path );
-        $this->assertContains( $styles->cdn_url, $contents );
-        $this->assertContains( '.bg{background:url(' . $styles->cdn_url, $contents );
+        $this->assertStringContainsString( $styles->cdn_url, $contents );
+        $this->assertStringContainsString( '.bg{background:url(' . $styles->cdn_url, $contents );
     }
 
     public function test_ao_partners_instantiation_without_explicit_include()
@@ -2387,7 +2387,13 @@ MARKUP;
         $this->assertSame( 2, autoptimizeUtils::strlen( "\x00\xFF", 'CP850' ) );
         $this->assertSame( 3, autoptimizeUtils::strlen( '한국어' ) );
 
-        $this->assertFalse( @autoptimizeUtils::strpos( 'abc', '' ) );
+        # https://php.watch/versions/8.0/string-function-empty-needles
+        if ( version_compare( PHP_VERSION, '8.0.0', '>=' ) ) {
+            $this->assertEmpty( @autoptimizeUtils::strpos( 'abc', '' ) );
+        } else {
+            $this->assertFalse( @autoptimizeUtils::strpos( 'abc', '' ) );
+        }
+
         $this->assertFalse( @autoptimizeUtils::strpos( 'abc', 'a', -1 ) );
         $this->assertFalse( autoptimizeUtils::strpos( 'abc', 'd' ) );
         $this->assertFalse( autoptimizeUtils::strpos( 'abc', 'a', 3 ) );


### PR DESCRIPTION
* Update .travis.yaml, add php8 and php8 compat code
* Fix potential strpos() call with null in autoptimizeBase
* Fix potential ord() call with null in jsmin.php
* Fix setUp/tearDown return types for php8 compat
* Use assertStringContainsString instead of assertContains for string assertions
* Branch out on 8.0 when asserting autoptimizeUtils::strpos()