### PR TITLE
More PHP 8.x compatibility for unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,24 +16,31 @@ php:
   - 7.2
   - 7.3
   - 7.4
-  - 8.1.0
+  - 8.0
 
 env:
   global:
     - WP_VERSION=latest
-  jobs:
-    - CUSTOM_CONSTANTS=0 WP_MULTISITE=0
-    - CUSTOM_CONSTANTS=1
-    - WP_MULTISITE=1
-    - CUSTOM_CONSTANTS=1 WP_MULTISITE=1
+
+matrix:
+  include:
+    - php: 8.0
+      env: WP_MULTISITE=1 CUSTOM_CONSTANTS=0
+    - php: 8.0
+      env: WP_MULTISITE=1 CUSTOM_CONSTANTS=1
+    - dist: focal
+      php: 8.1.2
+
+before_install:
+  - '[[ "$TRAVIS_PHP_VERSION" != "7.2" ]] || export PHPUNIT_UPGRADE=1'
 
 install:
     # flags to pass to install
   - flags="--ansi --prefer-dist --no-interaction --optimize-autoloader --no-progress"
 
-  # php 8.1.0 compat
-  - if [ "$TRAVIS_PHP_VERSION" == "8.1.0" ]; then rm composer.lock; fi
-  - if [ "$TRAVIS_PHP_VERSION" == "8.1.0" ]; then composer require --no-interaction --dev phpunit/phpunit:9.3; fi
+  # Upgrade phpunit for php 7.3 and higher
+  - if [ -z "$PHPUNIT_UPGRADE" ]; then rm composer.lock; fi
+  - if [ -z "$PHPUNIT_UPGRADE" ]; then composer require --no-interaction --dev phpunit/phpunit:9.3; fi
 
   # install dependencies using system provided composer binary
   - composer install $flags


### PR DESCRIPTION
* Use php 8.0.x and 8.1.2 in test matrix
* Force dist focal on php 8.1.2
* Run MULTISITE and CUSTOM_CONSTANTS variations on 8.0 only
* Upgrade to phpunit 9.3 on php 7.3 and higher