### PR TITLE
Refactor CriticalCSS classes

### DIFF
--- a/classes/autoptimizeCriticalCSSBase.php
+++ b/classes/autoptimizeCriticalCSSBase.php
@@ -145,7 +145,6 @@ class autoptimizeCriticalCSSBase {
         return $this->_core->ao_ccss_viewport();
     }
 
-
     /**
      * Check CCSS contents from Core object
      *
@@ -157,15 +156,31 @@ class autoptimizeCriticalCSSBase {
         return $this->_core->ao_ccss_check_contents( $ccss );
     }
 
+    /**
+     * Get key status from Core object
+     *
+     * @param bool $render
+     *
+     * @return array
+     */
     public function key_status( $render ) {
         return $this->_core->ao_ccss_key_status( $render );
+    }
+
+    /**
+     * Return valid types from core object
+     *
+     * @return array
+     */
+    public function get_types() {
+        return $this->_core->get_types();
     }
 
     /**
      * Run enqueue in CCSS Enqueue object
      */
     public function enqueue( $hash = '', $path = '', $type = 'is_page' ) {
-        return $this->_enqueue->ao_ccss_enqueue( $hash = '', $path = '', $type = 'is_page' );
+        return $this->_enqueue->ao_ccss_enqueue( $hash, $path, $type );
     }
 
     /**

--- a/classes/autoptimizeCriticalCSSBase.php
+++ b/classes/autoptimizeCriticalCSSBase.php
@@ -214,6 +214,10 @@ class autoptimizeCriticalCSSBase {
         return null;
     }
 
+    public function flush_options() {
+        $this->_options = null;
+    }
+
     protected function fetch_options() {
         if ( ! is_null( $this->_options ) ) {
             return $this->_options;

--- a/classes/autoptimizeCriticalCSSBase.php
+++ b/classes/autoptimizeCriticalCSSBase.php
@@ -180,6 +180,11 @@ class autoptimizeCriticalCSSBase {
      * Run enqueue in CCSS Enqueue object
      */
     public function enqueue( $hash = '', $path = '', $type = 'is_page' ) {
+        // Enqueue is sometimes required on wp-admin requests, load it just-in-time.
+        if ( is_null( $this->_enqueue ) ) {
+            $this->_enqueue = new autoptimizeCriticalCSSEnqueue();
+        }
+
         return $this->_enqueue->ao_ccss_enqueue( $hash, $path, $type );
     }
 

--- a/classes/autoptimizeCriticalCSSCore.php
+++ b/classes/autoptimizeCriticalCSSCore.php
@@ -9,94 +9,93 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class autoptimizeCriticalCSSCore {
-    public function __construct()
-    {
-        // fetch all options at once and populate them individually explicitely as globals.
-        $all_options = autoptimizeCriticalCSSBase::fetch_options();
-        foreach ( $all_options as $_option => $_value ) {
-            global ${$_option};
-            ${$_option} = $_value;
-        }
-
+    public function __construct() {
+        $this->criticalcss = autoptimize()->criticalcss();
         $this->run();
     }
 
     public function run() {
-        global $ao_css_defer;
-        global $ao_ccss_deferjquery;
-        global $ao_ccss_key;
-        global $ao_ccss_unloadccss;
+        $key = $this->criticalcss->get_option( 'key' );
+        $css_defer = $this->criticalcss->get_option( 'css_defer' );
+        $deferjquery = $this->criticalcss->get_option( 'deferjquery' );
+        $unloadccss = $this->criticalcss->get_option( 'unloadccss' );
 
-        // add all filters to do CCSS if key present.
-        if ( $ao_css_defer && isset( $ao_ccss_key ) && ! empty( $ao_ccss_key ) ) {
-            // Set AO behavior: disable minification to avoid double minifying and caching.
-            add_filter( 'autoptimize_filter_css_critcss_minify', '__return_false' );
-            add_filter( 'autoptimize_filter_css_defer_inline', array( $this, 'ao_ccss_frontend' ), 10, 1 );
-
-            // Add the action to enqueue jobs for CriticalCSS cron.
-            add_action( 'autoptimize_action_css_hash', array( 'autoptimizeCriticalCSSEnqueue', 'ao_ccss_enqueue' ), 10, 1 );
-
-            // conditionally add the filter to defer jquery and others but only if not done so in autoptimizeScripts.
-            $_native_defer = false;
-            if ( 'on' === autoptimizeOptionWrapper::get_option( 'autoptimize_js_defer_not_aggregate' ) && 'on' === autoptimizeOptionWrapper::get_option( 'autoptimize_js_defer_inline' ) ) {
-                $_native_defer = true;
-            }
-            if ( $ao_ccss_deferjquery && ! $_native_defer ) {
-                add_filter( 'autoptimize_html_after_minify', array( $this, 'ao_ccss_defer_jquery' ), 11, 1 );
-            }
-
-            // conditionally add filter to unload the CCSS.
-            if ( $ao_ccss_unloadccss ) {
-                add_filter( 'autoptimize_html_after_minify', array( $this, 'ao_ccss_unloadccss' ), 12, 1 );
-            }
-
-            // Order paths by length, as longest ones have greater priority in the rules.
-            if ( ! empty( $ao_ccss_rules['paths'] ) ) {
-                $keys = array_map( 'strlen', array_keys( $ao_ccss_rules['paths'] ) );
-                array_multisort( $keys, SORT_DESC, $ao_ccss_rules['paths'] );
-            }
-
-            // Add an array with default WordPress's conditional tags
-            // NOTE: these tags are sorted.
-            global $ao_ccss_types;
-            $ao_ccss_types = $this->get_ao_ccss_core_types();
-
-            // Extend conditional tags on plugin initalization.
-            add_action( apply_filters( 'autoptimize_filter_ccss_extend_types_hook', 'init' ), array( $this, 'ao_ccss_extend_types' ) );
-
-            // When autoptimize cache is cleared, also clear transient cache for page templates.
-            add_action( 'autoptimize_action_cachepurged', array( 'autoptimizeCriticalCSSCore', 'ao_ccss_clear_page_tpl_cache' ), 10, 0 );
+        if ( ! $css_defer || empty( $key ) ) {
+            return;
         }
+
+        // add all filters to do CCSS
+        // Set AO behavior: disable minification to avoid double minifying and caching.
+        add_filter( 'autoptimize_filter_css_critcss_minify', '__return_false' );
+        add_filter( 'autoptimize_filter_css_defer_inline', array( $this, 'ao_ccss_frontend' ), 10, 1 );
+
+        // Add the action to enqueue jobs for CriticalCSS cron.
+        add_action( 'autoptimize_action_css_hash', array( $this->criticalcss, 'enqueue' ), 10, 1 );
+
+        // conditionally add the filter to defer jquery and others but only if not done so in autoptimizeScripts.
+        $_native_defer = false;
+        if ( 'on' === autoptimizeOptionWrapper::get_option( 'autoptimize_js_defer_not_aggregate' ) && 'on' === autoptimizeOptionWrapper::get_option( 'autoptimize_js_defer_inline' ) ) {
+            $_native_defer = true;
+        }
+        if ( $deferjquery && ! $_native_defer ) {
+            add_filter( 'autoptimize_html_after_minify', array( $this, 'ao_ccss_defer_jquery' ), 11, 1 );
+        }
+
+        // conditionally add filter to unload the CCSS.
+        if ( $unloadccss ) {
+            add_filter( 'autoptimize_html_after_minify', array( $this, 'ao_ccss_unloadccss' ), 12, 1 );
+        }
+
+        // Order paths by length, as longest ones have greater priority in the rules.
+        $rules = $this->criticalcss->get_option( 'rules' );
+        if ( ! empty( $rules['paths'] ) ) {
+            $keys = array_map( 'strlen', array_keys( $rules['paths'] ) );
+            array_multisort( $keys, SORT_DESC, $rules['paths'] );
+            // TODO: Not sure what we're doing here. Sorted the $keys,
+            // but they don't seem to be used anywhere.
+        }
+
+        // Add an array with default WordPress's conditional tags
+        // NOTE: these tags are sorted.
+        global $ao_ccss_types;
+        $ao_ccss_types = $this->get_ao_ccss_core_types();
+
+        // Extend conditional tags on plugin initalization.
+        add_action( apply_filters( 'autoptimize_filter_ccss_extend_types_hook', 'init' ), array( $this, 'ao_ccss_extend_types' ) );
+
+        // When autoptimize cache is cleared, also clear transient cache for page templates.
+        add_action( 'autoptimize_action_cachepurged', array( $this, 'ao_ccss_clear_page_tpl_cache' ), 10, 0 );
     }
 
     public function ao_ccss_frontend( $inlined ) {
         // Apply CriticalCSS to frontend pages
         // Attach types and settings arrays.
-        global $ao_ccss_types;
-        global $ao_ccss_rules;
-        global $ao_ccss_additional;
-        global $ao_ccss_loggedin;
-        global $ao_ccss_debug;
-        global $ao_ccss_keyst;
+        global $ao_ccss_types; // TODO: Seems generated on the go.
+
+        $rules = $this->criticalcss->get_option( 'rules' );
+        $additional = $this->criticalcss->get_option( 'additional' );
+        $loggedin = $this->criticalcss->get_option( 'loggedin' );
+        $debug = $this->criticalcss->get_option( 'debug' );
+        $keyst = $this->criticalcss->get_option( 'keyst' );
 
         $no_ccss = '';
-        $ao_ccss_additional = autoptimizeStyles::sanitize_css( $ao_ccss_additional );
+        $additional = autoptimizeStyles::sanitize_css( $additional );
 
         // Only if keystatus is OK and option to add CCSS for logged on users is on or user is not logged in.
-        if ( ( $ao_ccss_keyst && 2 == $ao_ccss_keyst ) && ( $ao_ccss_loggedin || ! is_user_logged_in() ) ) {
+        if ( ( $keyst && 2 == $keyst ) && ( $loggedin || ! is_user_logged_in() ) ) {
             // Check for a valid CriticalCSS based on path to return its contents.
             $req_path = strtok( $_SERVER['REQUEST_URI'], '?' );
-            if ( ! empty( $ao_ccss_rules['paths'] ) ) {
-                foreach ( $ao_ccss_rules['paths'] as $path => $rule ) {
+            if ( ! empty( $rules['paths'] ) ) {
+                foreach ( $rules['paths'] as $path => $rule ) {
                     // explicit match OR partial match if MANUAL rule.
                     if ( $req_path == $path || urldecode( $req_path ) == $path || ( apply_filters( 'autoptimize_filter_ccss_core_path_partial_match', true ) && false == $rule['hash'] && false != $rule['file'] && strpos( $req_path, str_replace( site_url(), '', $path ) ) !== false ) ) {
                         if ( file_exists( AO_CCSS_DIR . $rule['file'] ) ) {
                             $_ccss_contents = file_get_contents( AO_CCSS_DIR . $rule['file'] );
                             if ( 'none' != $_ccss_contents ) {
-                                if ( $ao_ccss_debug ) {
+                                if ( $debug ) {
                                     $_ccss_contents = '/* PATH: ' . $path . ' hash: ' . $rule['hash'] . ' file: ' . $rule['file'] . ' */ ' . $_ccss_contents;
                                 }
-                                return apply_filters( 'autoptimize_filter_ccss_core_ccss', $_ccss_contents . $ao_ccss_additional );
+                                return apply_filters( 'autoptimize_filter_ccss_core_ccss', $_ccss_contents . $additional );
                             } else {
                                 $no_ccss = 'none';
                             }
@@ -106,30 +105,30 @@ class autoptimizeCriticalCSSCore {
             }
 
             // Check for a valid CriticalCSS based on conditional tags to return its contents.
-            if ( ! empty( $ao_ccss_rules['types'] ) && 'none' !== $no_ccss ) {
+            if ( ! empty( $rules['types'] ) && 'none' !== $no_ccss ) {
                 // order types-rules by the order of the original $ao_ccss_types array so as not to depend on the order in which rules were added.
-                $ao_ccss_rules['types'] = array_replace( array_intersect_key( array_flip( $ao_ccss_types ), $ao_ccss_rules['types'] ), $ao_ccss_rules['types'] );
+                $rules['types'] = array_replace( array_intersect_key( array_flip( $ao_ccss_types ), $rules['types'] ), $rules['types'] );
                 $is_front_page          = is_front_page();
 
-                foreach ( $ao_ccss_rules['types'] as $type => $rule ) {
+                foreach ( $rules['types'] as $type => $rule ) {
                     if ( in_array( $type, $ao_ccss_types ) && file_exists( AO_CCSS_DIR . $rule['file'] ) ) {
                         $_ccss_contents = file_get_contents( AO_CCSS_DIR . $rule['file'] );
                         if ( $is_front_page && 'is_front_page' == $type ) {
                             if ( 'none' != $_ccss_contents ) {
-                                if ( $ao_ccss_debug ) {
+                                if ( $debug ) {
                                     $_ccss_contents = '/* TYPES: ' . $type . ' hash: ' . $rule['hash'] . ' file: ' . $rule['file'] . ' */ ' . $_ccss_contents;
                                 }
-                                return apply_filters( 'autoptimize_filter_ccss_core_ccss', $_ccss_contents . $ao_ccss_additional );
+                                return apply_filters( 'autoptimize_filter_ccss_core_ccss', $_ccss_contents . $additional );
                             } else {
                                 $no_ccss = 'none';
                             }
                         } elseif ( strpos( $type, 'custom_post_' ) === 0 && ! $is_front_page ) {
                             if ( get_post_type( get_the_ID() ) === substr( $type, 12 ) ) {
                                 if ( 'none' != $_ccss_contents ) {
-                                    if ( $ao_ccss_debug ) {
+                                    if ( $debug ) {
                                         $_ccss_contents = '/* TYPES: ' . $type . ' hash: ' . $rule['hash'] . ' file: ' . $rule['file'] . ' */ ' . $_ccss_contents;
                                     }
-                                    return apply_filters( 'autoptimize_filter_ccss_core_ccss', $_ccss_contents . $ao_ccss_additional );
+                                    return apply_filters( 'autoptimize_filter_ccss_core_ccss', $_ccss_contents . $additional );
                                 } else {
                                     $no_ccss = 'none';
                                 }
@@ -137,10 +136,10 @@ class autoptimizeCriticalCSSCore {
                         } elseif ( 0 === strpos( $type, 'template_' ) && ! $is_front_page ) {
                             if ( is_page_template( substr( $type, 9 ) ) ) {
                                 if ( 'none' != $_ccss_contents ) {
-                                    if ( $ao_ccss_debug ) {
+                                    if ( $debug ) {
                                         $_ccss_contents = '/* TYPES: ' . $type . ' hash: ' . $rule['hash'] . ' file: ' . $rule['file'] . ' */ ' . $_ccss_contents;
                                     }
-                                    return apply_filters( 'autoptimize_filter_ccss_core_ccss', $_ccss_contents . $ao_ccss_additional );
+                                    return apply_filters( 'autoptimize_filter_ccss_core_ccss', $_ccss_contents . $additional );
                                 } else {
                                     $no_ccss = 'none';
                                 }
@@ -151,10 +150,10 @@ class autoptimizeCriticalCSSCore {
                             $type = str_replace( array( 'woo_', 'bp_', 'bbp_', 'edd_' ), '', $type );
                             if ( function_exists( $type ) && call_user_func( $type ) ) {
                                 if ( 'none' != $_ccss_contents ) {
-                                    if ( $ao_ccss_debug ) {
+                                    if ( $debug ) {
                                         $_ccss_contents = '/* TYPES: ' . $type . ' hash: ' . $rule['hash'] . ' file: ' . $rule['file'] . ' */ ' . $_ccss_contents;
                                     }
-                                    return apply_filters( 'autoptimize_filter_ccss_core_ccss', $_ccss_contents . $ao_ccss_additional );
+                                    return apply_filters( 'autoptimize_filter_ccss_core_ccss', $_ccss_contents . $additional );
                                 } else {
                                     $no_ccss = 'none';
                                 }
@@ -168,7 +167,7 @@ class autoptimizeCriticalCSSCore {
         // Finally, inline the default CriticalCSS if any or else the entire CSS for the page
         // This also applies to logged in users if the option to add CCSS for logged in users has been disabled.
         if ( ! empty( $inlined ) && 'none' !== $no_ccss ) {
-            return apply_filters( 'autoptimize_filter_ccss_core_ccss', $inlined . $ao_ccss_additional );
+            return apply_filters( 'autoptimize_filter_ccss_core_ccss', $inlined . $additional );
         } else {
             add_filter( 'autoptimize_filter_css_inline', '__return_true' );
             return;
@@ -176,9 +175,10 @@ class autoptimizeCriticalCSSCore {
     }
 
     public function ao_ccss_defer_jquery( $in ) {
-        global $ao_ccss_loggedin;
+        $loggedin = $this->criticalcss->get_option( 'loggedin' );
+
         // defer all linked and inline JS.
-        if ( ( ! is_user_logged_in() || $ao_ccss_loggedin ) && preg_match_all( '#<script.*>(.*)</script>#Usmi', $in, $matches, PREG_SET_ORDER ) ) {
+        if ( ( ! is_user_logged_in() || $loggedin ) && preg_match_all( '#<script.*>(.*)</script>#Usmi', $in, $matches, PREG_SET_ORDER ) ) {
             foreach ( $matches as $match ) {
                 if ( str_replace( apply_filters( 'autoptimize_filter_ccss_core_defer_exclude', array( 'data-noptimize="1"', 'data-cfasync="false"', 'data-pagespeed-no-defer' ) ), '', $match[0] ) !== $match[0] ) {
                     // do not touch JS with noptimize/ cfasync/ pagespeed-no-defer flags.
@@ -211,12 +211,12 @@ class autoptimizeCriticalCSSCore {
     public function ao_ccss_extend_types() {
         // Extend contidional tags
         // Attach the conditional tags array.
-        global $ao_ccss_types;
+        global $ao_ccss_types; // TODO: non-global.
 
         // in some cases $ao_ccss_types is empty and/or not an array, this should work around that problem.
         if ( empty( $ao_ccss_types ) || ! is_array( $ao_ccss_types ) ) {
             $ao_ccss_types = get_ao_ccss_core_types();
-            autoptimizeCriticalCSSCore::ao_ccss_log( 'Empty types array in extend, refetching array with core conditionals.', 3 );
+            $this->ao_ccss_log( 'Empty types array in extend, refetching array with core conditionals.', 3 );
         }
 
         // Custom Post Types.
@@ -348,7 +348,7 @@ class autoptimizeCriticalCSSCore {
     }
 
     public function get_ao_ccss_core_types() {
-        global $ao_ccss_types;
+        global $ao_ccss_types; // TODO: non-global
         if ( empty( $ao_ccss_types ) || ! is_array( $ao_ccss_types ) ) {
             return array(
                 'is_404',
@@ -370,14 +370,11 @@ class autoptimizeCriticalCSSCore {
         }
     }
 
-    public static function ao_ccss_key_status( $render ) {
+    public function ao_ccss_key_status( $render ) {
         // Provide key status
         // Get key and key status.
-        global $ao_ccss_key;
-        global $ao_ccss_keyst;
-        $self       = new self();
-        $key        = $ao_ccss_key;
-        $key_status = $ao_ccss_keyst;
+        $key = $this->criticalcss->get_option( 'key' );
+        $key_status = $this->criticalcss->get_option( 'keyst' );
 
         // Prepare returned variables.
         $key_return = array();
@@ -442,14 +439,14 @@ class autoptimizeCriticalCSSCore {
     }
 
     public function ao_ccss_key_validation( $key ) {
-        global $ao_ccss_noptimize;
+        $noptimize = $this->criticalcss->get_option( 'noptimize' );
 
         // POST a dummy job to criticalcss.com to check for key validation
         // Prepare home URL for the request.
         $src_url = get_home_url();
 
         // Avoid AO optimizations if required by config or avoid lazyload if lazyload is active in AO.
-        if ( ! empty( $ao_ccss_noptimize ) ) {
+        if ( ! empty( $noptimize ) ) {
             $src_url .= '?ao_noptirocket=1';
         } elseif ( class_exists( 'autoptimizeImages', false ) && autoptimizeImages::should_lazyload_wrapper() ) {
             $src_url .= '?ao_nolazy=1';
@@ -487,14 +484,14 @@ class autoptimizeCriticalCSSCore {
             // Response is OK.
             // Set key status as valid and log key check.
             update_option( 'autoptimize_ccss_keyst', 2 );
-            autoptimizeCriticalCSSCore::ao_ccss_log( 'criticalcss.com: API key is valid, updating key status', 3 );
+            $this->ao_ccss_log( 'criticalcss.com: API key is valid, updating key status', 3 );
 
             // extract job-id from $body and put it in the queue as a P job
             // but only if no jobs and no rules!
-            global $ao_ccss_queue;
-            global $ao_ccss_rules;
+            $queue = $this->criticalcss->get_option( 'queue' );
+            $rules = $this->criticalcss->get_option( 'rules' );
 
-            if ( 0 == count( $ao_ccss_queue ) && 0 == count( $ao_ccss_rules['types'] ) && 0 == count( $ao_ccss_rules['paths'] ) ) {
+            if ( 0 == count( $queue ) && 0 == count( $rules['types'] ) && 0 == count( $rules['paths'] ) ) {
                 if ( 'JOB_QUEUED' == $body['job']['status'] || 'JOB_ONGOING' == $body['job']['status'] ) {
                     $jprops['ljid']     = 'firstrun';
                     $jprops['rtarget']  = 'types|is_front_page';
@@ -508,10 +505,10 @@ class autoptimizeCriticalCSSCore {
                     $jprops['jvstat']   = null;
                     $jprops['jctime']   = microtime( true );
                     $jprops['jftime']   = null;
-                    $ao_ccss_queue['/'] = $jprops;
-                    $ao_ccss_queue_raw  = json_encode( $ao_ccss_queue );
-                    update_option( 'autoptimize_ccss_queue', $ao_ccss_queue_raw, false );
-                    autoptimizeCriticalCSSCore::ao_ccss_log( 'Created P job for is_front_page based on API key check response.', 3 );
+                    $queue['/'] = $jprops;
+                    $queue_raw  = json_encode( $queue );
+                    update_option( 'autoptimize_ccss_queue', $queue_raw, false );
+                    $this->ao_ccss_log( 'Created P job for is_front_page based on API key check response.', 3 );
                 }
             }
             return true;
@@ -519,55 +516,41 @@ class autoptimizeCriticalCSSCore {
             // Response is unauthorized
             // Set key status as invalid and log key check.
             update_option( 'autoptimize_ccss_keyst', 1 );
-            autoptimizeCriticalCSSCore::ao_ccss_log( 'criticalcss.com: API key is invalid, updating key status', 3 );
+            $this->ao_ccss_log( 'criticalcss.com: API key is invalid, updating key status', 3 );
             return false;
         } else {
             // Response unkown
             // Log key check attempt.
-            autoptimizeCriticalCSSCore::ao_ccss_log( 'criticalcss.com: could not check API key status, this is a service error, body follows if any...', 2 );
+            $this->ao_ccss_log( 'criticalcss.com: could not check API key status, this is a service error, body follows if any...', 2 );
             if ( ! empty( $body ) ) {
-                autoptimizeCriticalCSSCore::ao_ccss_log( print_r( $body, true ), 2 );
+                $this->ao_ccss_log( print_r( $body, true ), 2 );
             }
             if ( is_wp_error( $req ) ) {
-                autoptimizeCriticalCSSCore::ao_ccss_log( $req->get_error_message(), 2 );
+                $this->ao_ccss_log( $req->get_error_message(), 2 );
             }
             return false;
         }
     }
 
-    public static function ao_ccss_viewport() {
+    public function ao_ccss_viewport() {
         // Get viewport size
         // Attach viewport option.
-        global $ao_ccss_viewport;
+        $viewport = $this->criticalcss->get_option( 'noptimize' );
 
-        // Prepare viewport array.
-        $viewport = array();
-
-        // Viewport Width.
-        if ( ! empty( $ao_ccss_viewport['w'] ) ) {
-            $viewport['w'] = $ao_ccss_viewport['w'];
-        } else {
-            $viewport['w'] = '';
-        }
-
-        // Viewport Height.
-        if ( ! empty( $ao_ccss_viewport['h'] ) ) {
-            $viewport['h'] = $ao_ccss_viewport['h'];
-        } else {
-            $viewport['h'] = '';
-        }
-
-        return $viewport;
+        return array(
+            'w' => ! empty( $viewport['w'] ) ? $viewport['w'] : '',
+            'h' => ! empty( $viewport['h'] ) ? $viewport['h'] : '',
+        );
     }
 
-    public static function ao_ccss_check_contents( $ccss ) {
+    public function ao_ccss_check_contents( $ccss ) {
         // Perform basic exploit avoidance and CSS validation.
         if ( ! empty( $ccss ) ) {
             // Try to avoid code injection.
             $blocklist = array( '#!/', 'function(', '<script', '<?php' );
             foreach ( $blocklist as $blocklisted ) {
                 if ( strpos( $ccss, $blocklisted ) !== false ) {
-                    autoptimizeCriticalCSSCore::ao_ccss_log( 'Critical CSS received contained blocklisted content.', 2 );
+                    $this->ao_ccss_log( 'Critical CSS received contained blocklisted content.', 2 );
                     return false;
                 }
             }
@@ -576,7 +559,7 @@ class autoptimizeCriticalCSSCore {
             $needlist = array( '{', '}', ':' );
             foreach ( $needlist as $needed ) {
                 if ( false === strpos( $ccss, $needed ) && 'none' !== $ccss ) {
-                    autoptimizeCriticalCSSCore::ao_ccss_log( 'Critical CSS received did not seem to contain real CSS.', 2 );
+                    $this->ao_ccss_log( 'Critical CSS received did not seem to contain real CSS.', 2 );
                     return false;
                 }
             }
@@ -586,10 +569,10 @@ class autoptimizeCriticalCSSCore {
         return true;
     }
 
-    public static function ao_ccss_log( $msg, $lvl ) {
+    public function ao_ccss_log( $msg, $lvl ) {
         // Commom logging facility
         // Attach debug option.
-        global $ao_ccss_debug;
+        $debug = $this->criticalcss->get_option( 'debug' );
 
         // Prepare log levels, where accepted $lvl are:
         // 1: II (for info)
@@ -606,7 +589,7 @@ class autoptimizeCriticalCSSCore {
                 break;
             case 3:
                 // Output debug messages only if debug mode is enabled.
-                if ( $ao_ccss_debug ) {
+                if ( $debug ) {
                     $level = 'DD';
                 }
                 break;
@@ -625,9 +608,8 @@ class autoptimizeCriticalCSSCore {
         }
     }
 
-    public static function ao_ccss_clear_page_tpl_cache() {
+    public function ao_ccss_clear_page_tpl_cache() {
         // Clears transient cache for page templates.
         delete_transient( 'autoptimize_ccss_page_templates' );
     }
-
 }

--- a/classes/autoptimizeCriticalCSSCore.php
+++ b/classes/autoptimizeCriticalCSSCore.php
@@ -537,7 +537,7 @@ class autoptimizeCriticalCSSCore {
     public function ao_ccss_viewport() {
         // Get viewport size
         // Attach viewport option.
-        $viewport = $this->criticalcss->get_option( 'noptimize' );
+        $viewport = $this->criticalcss->get_option( 'viewport' );
 
         return array(
             'w' => ! empty( $viewport['w'] ) ? $viewport['w'] : '',

--- a/classes/autoptimizeCriticalCSSCron.php
+++ b/classes/autoptimizeCriticalCSSCron.php
@@ -319,10 +319,10 @@ class autoptimizeCriticalCSSCron {
                 if ( $update ) {
                     if ( ! $deljob ) {
                         // Update properties of a NEW or PENDING job...
-                        $ao_ccss_queue[ $path ] = $jprops;
+                        $queue[ $path ] = $jprops;
                     } else {
                         // ...or remove the DONE job.
-                        unset( $ao_ccss_queue[ $path ] );
+                        unset( $queue[ $path ] );
                         $this->criticalcss->log( 'Job id <' . $jprops['ljid'] . '> is DONE and was removed from the queue', 3 );
                     }
 
@@ -660,7 +660,7 @@ class autoptimizeCriticalCSSCron {
                 return $filename;
             }
         } else {
-            $this->criticalcss->( 'Critical CSS received did not pass content check', 2 );
+            $this->criticalcss->log( 'Critical CSS received did not pass content check', 2 );
             return $filename;
         }
 

--- a/classes/autoptimizeCriticalCSSCron.php
+++ b/classes/autoptimizeCriticalCSSCron.php
@@ -9,14 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class autoptimizeCriticalCSSCron {
-    public function __construct()
-    {
-        // fetch all options at once and populate them individually explicitely as globals.
-        $all_options = autoptimizeCriticalCSSBase::fetch_options();
-        foreach ( $all_options as $_option => $_value ) {
-            global ${$_option};
-            ${$_option} = $_value;
-        }
+    public function __construct() {
+        $this->criticalcss = autoptimize()->criticalcss();
 
         // Add queue control to a registered event.
         add_action( 'ao_ccss_queue', array( $this, 'ao_ccss_queue_control' ) );
@@ -26,10 +20,11 @@ class autoptimizeCriticalCSSCron {
 
     public function ao_ccss_queue_control() {
         // The queue execution backend.
-        global $ao_ccss_key;
-        if ( ! isset( $ao_ccss_key ) || empty( $ao_ccss_key ) ) {
+        $key = $this->criticalcss->get_option( 'key' );
+
+        if ( empty( $key ) ) {
             // no key set, not processing the queue!
-            autoptimizeCriticalCSSCore::ao_ccss_log( 'No key set, so not processing queue.', 3 );
+            $this->criticalcss->log( 'No key set, so not processing queue.', 3 );
             return;
         }
 
@@ -56,7 +51,7 @@ class autoptimizeCriticalCSSCron {
             if ( $qdobj ) {
                 if ( 1 === $qdobj['enable'] ) {
                     $queue_debug = true;
-                    autoptimizeCriticalCSSCore::ao_ccss_log( 'Queue operating in debug mode with the following settings: <' . $qdobj_raw . '>', 3 );
+                    $this->criticalcss->log( 'Queue operating in debug mode with the following settings: <' . $qdobj_raw . '>', 3 );
                 }
             }
         }
@@ -76,30 +71,30 @@ class autoptimizeCriticalCSSCron {
         if ( ! $queue_lock ) {
 
             // Log queue start and create the lock file.
-            autoptimizeCriticalCSSCore::ao_ccss_log( 'Queue control started', 3 );
+            $this->criticalcss->log( 'Queue control started', 3 );
             if ( touch( AO_CCSS_LOCK ) ) {
-                autoptimizeCriticalCSSCore::ao_ccss_log( 'Queue control locked', 3 );
+                $this->criticalcss->log( 'Queue control locked', 3 );
             }
 
             // Attach required variables.
-            global $ao_ccss_queue;
-            global $ao_ccss_rtimelimit;
+            $queue = $this->criticalcss->get_option( 'queue' );
+            $rtimelimit = $this->criticalcss->get_option( 'rtimelimit' );
 
             // Initialize counters.
-            if ( $ao_ccss_rtimelimit == 0 ) {
+            if ( $rtimelimit == 0 ) {
                 // no time limit set, let's go with 1000 seconds.
-                $ao_ccss_rtimelimit = 1000;
+                $rtimelimit = 1000;
             }
-            $mt = time() + $ao_ccss_rtimelimit; // maxtime queue processing can run.
+            $mt = time() + $rtimelimit; // maxtime queue processing can run.
             $jc = 1; // job count number.
             $jr = 1; // jobs requests number.
-            $jt = count( $ao_ccss_queue ); // number of jobs in queue.
+            $jt = count( $queue ); // number of jobs in queue.
 
             // Sort queue by ascending job status (e.g. ERROR, JOB_ONGOING, JOB_QUEUED, NEW...).
-            array_multisort( array_column( $ao_ccss_queue, 'jqstat' ), $ao_ccss_queue ); // @codingStandardsIgnoreLine
+            array_multisort( array_column( $queue, 'jqstat' ), $queue ); // @codingStandardsIgnoreLine
 
             // Iterates over the entire queue.
-            foreach ( $ao_ccss_queue as $path => $jprops ) {
+            foreach ( $queue as $path => $jprops ) {
                 // Prepare flags and target rule.
                 $update      = false;
                 $deljob      = false;
@@ -108,13 +103,13 @@ class autoptimizeCriticalCSSCron {
                 $trule       = explode( '|', $jprops['rtarget'] );
 
                 // Log job count.
-                autoptimizeCriticalCSSCore::ao_ccss_log( 'Processing job ' . $jc . ' of ' . $jt . ' with id <' . $jprops['ljid'] . '> and status <' . $jprops['jqstat'] . '>', 3 );
+                $this->criticalcss->log( 'Processing job ' . $jc . ' of ' . $jt . ' with id <' . $jprops['ljid'] . '> and status <' . $jprops['jqstat'] . '>', 3 );
 
                 // Process NEW jobs.
                 if ( 'NEW' == $jprops['jqstat'] ) {
 
                     // Log the new job.
-                    autoptimizeCriticalCSSCore::ao_ccss_log( 'Found NEW job with local ID <' . $jprops['ljid'] . '>, starting its queue processing', 3 );
+                    $this->criticalcss->log( 'Found NEW job with local ID <' . $jprops['ljid'] . '>, starting its queue processing', 3 );
 
                     // Compare job and rule hashes (if any).
                     $hash = $this->ao_ccss_diff_hashes( $jprops['ljid'], $jprops['hash'], $jprops['hashes'], $jprops['rtarget'] );
@@ -124,7 +119,7 @@ class autoptimizeCriticalCSSCron {
                         if ( $jr > 2 ) {
                             // we already posted 2 jobs to criticalcss.com, don't post more this run
                             // but we can keep on processing the queue to keep it tidy.
-                            autoptimizeCriticalCSSCore::ao_ccss_log( 'Holding off on generating request for job with local ID <' . $jprops['ljid'] . '>, maximum number of POSTS reached.', 3 );
+                            $this->criticalcss->log( 'Holding off on generating request for job with local ID <' . $jprops['ljid'] . '>, maximum number of POSTS reached.', 3 );
                             continue;
                         }
 
@@ -141,7 +136,7 @@ class autoptimizeCriticalCSSCron {
                             // Update job properties.
                             $jprops['jid']    = $apireq['job']['id'];
                             $jprops['jqstat'] = $apireq['job']['status'];
-                            autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $jprops['ljid'] . '> generate request successful, remote id <' . $jprops['jid'] . '>, status now is <' . $jprops['jqstat'] . '>', 3 );
+                            $this->criticalcss->log( 'Job id <' . $jprops['ljid'] . '> generate request successful, remote id <' . $jprops['jid'] . '>, status now is <' . $jprops['jqstat'] . '>', 3 );
                         } elseif ( 'STATUS_JOB_BAD' == $apireq['job']['status'] ) {
                             // ERROR: concurrent requests
                             // Update job properties.
@@ -154,7 +149,7 @@ class autoptimizeCriticalCSSCron {
                             }
                             $jprops['jvstat'] = 'NONE';
                             $jprops['jftime'] = microtime( true );
-                            autoptimizeCriticalCSSCore::ao_ccss_log( 'Concurrent requests when processing job id <' . $jprops['ljid'] . '>, job status is now <' . $jprops['jqstat'] . '>', 3 );
+                            $this->criticalcss->log( 'Concurrent requests when processing job id <' . $jprops['ljid'] . '>, job status is now <' . $jprops['jqstat'] . '>', 3 );
                         } elseif ( 'INVALID_JWT_TOKEN' == $apireq['errorCode'] ) {
                             // ERROR: key validation
                             // Update job properties.
@@ -162,7 +157,7 @@ class autoptimizeCriticalCSSCron {
                             $jprops['jrstat'] = $apireq['error'];
                             $jprops['jvstat'] = 'NONE';
                             $jprops['jftime'] = microtime( true );
-                            autoptimizeCriticalCSSCore::ao_ccss_log( 'API key validation error when processing job id <' . $jprops['ljid'] . '>, job status is now <' . $jprops['jqstat'] . '>', 3 );
+                            $this->criticalcss->log( 'API key validation error when processing job id <' . $jprops['ljid'] . '>, job status is now <' . $jprops['jqstat'] . '>', 3 );
                         } elseif ( empty( $apireq ) ) {
                             // ERROR: no response
                             // Update job properties.
@@ -170,7 +165,7 @@ class autoptimizeCriticalCSSCron {
                             $jprops['jrstat'] = 'NONE';
                             $jprops['jvstat'] = 'NONE';
                             $jprops['jftime'] = microtime( true );
-                            autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $jprops['ljid'] . '> request has no response, status now is <' . $jprops['jqstat'] . '>', 3 );
+                            $this->criticalcss->log( 'Job id <' . $jprops['ljid'] . '> request has no response, status now is <' . $jprops['jqstat'] . '>', 3 );
                         } else {
                             // UNKNOWN: unhandled generate exception
                             // Update job properties.
@@ -178,15 +173,15 @@ class autoptimizeCriticalCSSCron {
                             $jprops['jrstat'] = 'NONE';
                             $jprops['jvstat'] = 'NONE';
                             $jprops['jftime'] = microtime( true );
-                            autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $jprops['ljid'] . '> generate request has an UNKNOWN condition, status now is <' . $jprops['jqstat'] . '>, check log messages above for more information', 2 );
-                            autoptimizeCriticalCSSCore::ao_ccss_log( 'Job response was: ' . json_encode( $apireq ), 3 );
+                            $this->criticalcss->log( 'Job id <' . $jprops['ljid'] . '> generate request has an UNKNOWN condition, status now is <' . $jprops['jqstat'] . '>, check log messages above for more information', 2 );
+                            $this->criticalcss->log( 'Job response was: ' . json_encode( $apireq ), 3 );
                         }
                     } else {
                         // SUCCESS: Job hash is equal to a previous one, so it's done
                         // Update job status and finish time.
                         $jprops['jqstat'] = 'JOB_DONE';
                         $jprops['jftime'] = microtime( true );
-                        autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $jprops['ljid'] . '> requires no further processing, status now is <' . $jprops['jqstat'] . '>', 3 );
+                        $this->criticalcss->log( 'Job id <' . $jprops['ljid'] . '> requires no further processing, status now is <' . $jprops['jqstat'] . '>', 3 );
                     }
 
                     // Set queue update flag.
@@ -195,7 +190,7 @@ class autoptimizeCriticalCSSCron {
                 } elseif ( 'JOB_QUEUED' == $jprops['jqstat'] || 'JOB_ONGOING' == $jprops['jqstat'] ) {
                     // Process QUEUED and ONGOING jobs
                     // Log the pending job.
-                    autoptimizeCriticalCSSCore::ao_ccss_log( 'Found PENDING job with local ID <' . $jprops['ljid'] . '>, continuing its queue processing', 3 );
+                    $this->criticalcss->log( 'Found PENDING job with local ID <' . $jprops['ljid'] . '>, continuing its queue processing', 3 );
 
                     // Dispatch the job result request and increment request count.
                     $apireq = $this->ao_ccss_api_results( $jprops['jid'], $queue_debug, $qdobj['htcode'] );
@@ -219,7 +214,7 @@ class autoptimizeCriticalCSSCron {
                         // Process a PENDING job
                         // Update job properties.
                         $jprops['jqstat'] = $apireq['status'];
-                        autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $jprops['ljid'] . '> result request successful, remote id <' . $jprops['jid'] . '>, status <' . $jprops['jqstat'] . '> unchanged', 3 );
+                        $this->criticalcss->log( 'Job id <' . $jprops['ljid'] . '> result request successful, remote id <' . $jprops['jid'] . '>, status <' . $jprops['jqstat'] . '> unchanged', 3 );
                     } elseif ( 'JOB_DONE' == $apireq['status'] ) {
                         // Process a DONE job
                         // New resultStatus from ccss.com "HTML_404", consider as "GOOD" for now.
@@ -236,7 +231,7 @@ class autoptimizeCriticalCSSCron {
                             $jprops['jvstat'] = $apireq['validationStatus'];
                             $jprops['jftime'] = microtime( true );
                             $rule_update      = true;
-                            autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $jprops['ljid'] . '> result request successful, remote id <' . $jprops['jid'] . '>, status <' . $jprops['jqstat'] . '>, file saved <' . $jprops['file'] . '>', 3 );
+                            $this->criticalcss->log( 'Job id <' . $jprops['ljid'] . '> result request successful, remote id <' . $jprops['jid'] . '>, status <' . $jprops['jqstat'] . '>, file saved <' . $jprops['file'] . '>', 3 );
                         } elseif ( 'GOOD' == $apireq['resultStatus'] && ( 'BAD' == $apireq['validationStatus'] || 'SCREENSHOT_WARN_BLANK' == $apireq['validationStatus'] ) ) {
                             // SUCCESS: GOOD job with BAD or SCREENSHOT_WARN_BLANK validation
                             // Update job properties.
@@ -247,9 +242,9 @@ class autoptimizeCriticalCSSCron {
                             if ( apply_filters( 'autoptimize_filter_ccss_save_review_rules', true ) ) {
                                 $jprops['file']   = $this->ao_ccss_save_file( $apireq['css'], $trule, true );
                                 $rule_update      = true;
-                                autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $jprops['ljid'] . '> result request successful, remote id <' . $jprops['jid'] . '>, status <' . $jprops['jqstat'] . ', file saved <' . $jprops['file'] . '> but requires REVIEW', 3 );
+                                $this->criticalcss->log( 'Job id <' . $jprops['ljid'] . '> result request successful, remote id <' . $jprops['jid'] . '>, status <' . $jprops['jqstat'] . ', file saved <' . $jprops['file'] . '> but requires REVIEW', 3 );
                             } else {
-                                autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $jprops['ljid'] . '> result request successful, remote id <' . $jprops['jid'] . '>, status <' . $jprops['jqstat'] . ', file not saved because it required REVIEW.', 3 );
+                                $this->criticalcss->log( 'Job id <' . $jprops['ljid'] . '> result request successful, remote id <' . $jprops['jid'] . '>, status <' . $jprops['jqstat'] . ', file not saved because it required REVIEW.', 3 );
                             }
                         } elseif ( 'GOOD' != $apireq['resultStatus'] && ( 'GOOD' != $apireq['validationStatus'] || 'WARN' != $apireq['validationStatus'] || 'BAD' != $apireq['validationStatus'] || 'SCREENSHOT_WARN_BLANK' != $apireq['validationStatus'] ) ) {
                             // ERROR: no GOOD, WARN or BAD results
@@ -258,9 +253,9 @@ class autoptimizeCriticalCSSCron {
                             $jprops['jrstat'] = $apireq['resultStatus'];
                             $jprops['jvstat'] = $apireq['validationStatus'];
                             $jprops['jftime'] = microtime( true );
-                            autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $jprops['ljid'] . '> result request successful but job FAILED, status now is <' . $jprops['jqstat'] . '>', 3 );
+                            $this->criticalcss->log( 'Job id <' . $jprops['ljid'] . '> result request successful but job FAILED, status now is <' . $jprops['jqstat'] . '>', 3 );
                             $apireq['css'] = '/* critical css removed for DEBUG logging purposes */';
-                            autoptimizeCriticalCSSCore::ao_ccss_log( 'Job response was: ' . json_encode( $apireq ), 3 );
+                            $this->criticalcss->log( 'Job response was: ' . json_encode( $apireq ), 3 );
                         } else {
                             // UNKNOWN: unhandled JOB_DONE exception
                             // Update job properties.
@@ -268,9 +263,9 @@ class autoptimizeCriticalCSSCron {
                             $jprops['jrstat'] = $apireq['resultStatus'];
                             $jprops['jvstat'] = $apireq['validationStatus'];
                             $jprops['jftime'] = microtime( true );
-                            autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $jprops['ljid'] . '> result request successful but job is UNKNOWN, status now is <' . $jprops['jqstat'] . '>', 2 );
+                            $this->criticalcss->log( 'Job id <' . $jprops['ljid'] . '> result request successful but job is UNKNOWN, status now is <' . $jprops['jqstat'] . '>', 2 );
                             $apireq['css'] = '/* critical css removed for DEBUG logging purposes */';
-                            autoptimizeCriticalCSSCore::ao_ccss_log( 'Job response was: ' . json_encode( $apireq ), 3 );
+                            $this->criticalcss->log( 'Job response was: ' . json_encode( $apireq ), 3 );
                         }
                     } elseif ( 'JOB_FAILED' == $apireq['job']['status'] || 'STATUS_JOB_BAD' == $apireq['job']['status'] ) {
                         // ERROR: failed job
@@ -283,7 +278,7 @@ class autoptimizeCriticalCSSCron {
                         }
                         $jprops['jvstat'] = 'NONE';
                         $jprops['jftime'] = microtime( true );
-                        autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $jprops['ljid'] . '> result request successful but job FAILED, status now is <' . $jprops['jqstat'] . '>', 3 );
+                        $this->criticalcss->log( 'Job id <' . $jprops['ljid'] . '> result request successful but job FAILED, status now is <' . $jprops['jqstat'] . '>', 3 );
                     } elseif ( 'This css no longer exists. Please re-generate it.' == $apireq['error'] ) {
                         // ERROR: CSS doesn't exist
                         // Update job properties.
@@ -291,7 +286,7 @@ class autoptimizeCriticalCSSCron {
                         $jprops['jrstat'] = $apireq['error'];
                         $jprops['jvstat'] = 'NONE';
                         $jprops['jftime'] = microtime( true );
-                        autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $jprops['ljid'] . '> result request successful but job FAILED, status now is <' . $jprops['jqstat'] . '>', 3 );
+                        $this->criticalcss->log( 'Job id <' . $jprops['ljid'] . '> result request successful but job FAILED, status now is <' . $jprops['jqstat'] . '>', 3 );
                     } elseif ( empty( $apireq ) ) {
                         // ERROR: no response
                         // Update job properties.
@@ -299,7 +294,7 @@ class autoptimizeCriticalCSSCron {
                         $jprops['jrstat'] = 'NONE';
                         $jprops['jvstat'] = 'NONE';
                         $jprops['jftime'] = microtime( true );
-                        autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $jprops['ljid'] . '> request has no response, status now is <' . $jprops['jqstat'] . '>', 3 );
+                        $this->criticalcss->log( 'Job id <' . $jprops['ljid'] . '> request has no response, status now is <' . $jprops['jqstat'] . '>', 3 );
                     } else {
                         // UNKNOWN: unhandled results exception
                         // Update job properties.
@@ -307,7 +302,7 @@ class autoptimizeCriticalCSSCron {
                         $jprops['jrstat'] = 'NONE';
                         $jprops['jvstat'] = 'NONE';
                         $jprops['jftime'] = microtime( true );
-                        autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $jprops['ljid'] . '> result request has an UNKNOWN condition, status now is <' . $jprops['jqstat'] . '>, check log messages above for more information', 2 );
+                        $this->criticalcss->log( 'Job id <' . $jprops['ljid'] . '> result request has an UNKNOWN condition, status now is <' . $jprops['jqstat'] . '>, check log messages above for more information', 2 );
                     }
 
                     // Set queue update flag.
@@ -328,27 +323,27 @@ class autoptimizeCriticalCSSCron {
                     } else {
                         // ...or remove the DONE job.
                         unset( $ao_ccss_queue[ $path ] );
-                        autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $jprops['ljid'] . '> is DONE and was removed from the queue', 3 );
+                        $this->criticalcss->log( 'Job id <' . $jprops['ljid'] . '> is DONE and was removed from the queue', 3 );
                     }
 
                     // Update queue object.
-                    $ao_ccss_queue_raw = json_encode( $ao_ccss_queue );
-                    update_option( 'autoptimize_ccss_queue', $ao_ccss_queue_raw, false );
-                    autoptimizeCriticalCSSCore::ao_ccss_log( 'Queue updated by job id <' . $jprops['ljid'] . '>', 3 );
+                    $queue_raw = json_encode( $queue );
+                    update_option( 'autoptimize_ccss_queue', $queue_raw, false );
+                    $this->criticalcss->log( 'Queue updated by job id <' . $jprops['ljid'] . '>', 3 );
 
                     // Update target rule.
                     if ( $rule_update ) {
                         $this->ao_ccss_rule_update( $jprops['ljid'], $jprops['rtarget'], $jprops['file'], $jprops['hash'] );
-                        autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $jprops['ljid'] . '> updated the target rule <' . $jprops['rtarget'] . '>', 3 );
+                        $this->criticalcss->log( 'Job id <' . $jprops['ljid'] . '> updated the target rule <' . $jprops['rtarget'] . '>', 3 );
                     }
                 } else {
                     // Or log no queue action.
-                    autoptimizeCriticalCSSCore::ao_ccss_log( 'Nothing to do on this job', 3 );
+                    $this->criticalcss->log( 'Nothing to do on this job', 3 );
                 }
 
                 // Break the loop if request time limit is (almost exceeded).
                 if ( time() > $mt ) {
-                    autoptimizeCriticalCSSCore::ao_ccss_log( 'The time limit of ' . $ao_ccss_rtimelimit . ' seconds was exceeded, queue control must finish now', 3 );
+                    $this->criticalcss->log( 'The time limit of ' . $rtimelimit . ' seconds was exceeded, queue control must finish now', 3 );
                     break;
                 }
 
@@ -359,13 +354,13 @@ class autoptimizeCriticalCSSCron {
             // Remove the lock file and log the queue end.
             if ( file_exists( AO_CCSS_LOCK ) ) {
                 unlink( AO_CCSS_LOCK );
-                autoptimizeCriticalCSSCore::ao_ccss_log( 'Queue control unlocked', 3 );
+                $this->criticalcss->log( 'Queue control unlocked', 3 );
             }
-            autoptimizeCriticalCSSCore::ao_ccss_log( 'Queue control finished', 3 );
+            $this->criticalcss->log( 'Queue control finished', 3 );
 
             // Log that queue is locked.
         } else {
-            autoptimizeCriticalCSSCore::ao_ccss_log( 'Queue is already running, skipping the attempt to run it again', 3 );
+            $this->criticalcss->log( 'Queue is already running, skipping the attempt to run it again', 3 );
         }
     }
 
@@ -376,7 +371,7 @@ class autoptimizeCriticalCSSCron {
             // Job with a single hash
             // Set job hash.
             $hash = $hashes[0];
-            autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $ljid . '> updated with SINGLE hash <' . $hash . '>', 3 );
+            $this->criticalcss->log( 'Job id <' . $ljid . '> updated with SINGLE hash <' . $hash . '>', 3 );
         } else {
             // Job with multiple hashes
             // Loop through hashes to concatenate them.
@@ -387,52 +382,52 @@ class autoptimizeCriticalCSSCron {
 
             // Set job hash.
             $hash = md5( $nhash );
-            autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $ljid . '> updated with a COMPOSITE hash <' . $hash . '>', 3 );
+            $this->criticalcss->log( 'Job id <' . $ljid . '> updated with a COMPOSITE hash <' . $hash . '>', 3 );
         }
 
         // STEP 2: compare job to existing jobs to prevent double submission for same type+hash.
-        global $ao_ccss_queue;
+        $queue = $this->criticalcss->get_option( 'queue' );
 
-        foreach ( $ao_ccss_queue as $queue_item ) {
-            autoptimizeCriticalCSSCore::ao_ccss_log( 'Comparing <' . $rule . $hash . '> with <' . $queue_item['rtarget'] . $queue_item['hash'] . '>', 3 );
+        foreach ( $queue as $queue_item ) {
+            $this->criticalcss->log( 'Comparing <' . $rule . $hash . '> with <' . $queue_item['rtarget'] . $queue_item['hash'] . '>', 3 );
             if ( $queue_item['hash'] == $hash && $queue_item['rtarget'] == $rule && in_array( $queue_item['jqstat'], array( 'JOB_QUEUED', 'JOB_ONGOING', 'JOB_DONE' ) ) ) {
-                autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $ljid . '> matches the already pending job <' . $queue_item['ljid'] . '>', 3 );
+                $this->criticalcss->log( 'Job id <' . $ljid . '> matches the already pending job <' . $queue_item['ljid'] . '>', 3 );
                 return false;
             }
         }
 
         // STEP 3: compare job and existing rule (if any) hashes
         // Attach required arrays.
-        global $ao_ccss_rules;
+        $rules = $this->criticalcss->get_option( 'rules' );
 
         // Prepare rule variables.
         $trule = explode( '|', $rule );
-        $srule = $ao_ccss_rules[ $trule[0] ][ $trule[1] ];
-        
+        $srule = $rules[ $trule[0] ][ $trule[1] ];
+
         // If hash is empty, set it to now for a "forced job".
-        if ( empty( $hash  )  ) {     
+        if ( empty( $hash ) ) {
             $hash = 'new';
-            autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $ljid . '> had no hash, assuming forced job so setting hash to new', 3   );  
+            $this->criticalcss->log( 'Job id <' . $ljid . '> had no hash, assuming forced job so setting hash to new', 3 );
         }
 
         // Check if a MANUAL rule exist and return false.
         if ( ! empty( $srule ) && ( 0 == $srule['hash'] && 0 != $srule['file'] ) ) {
-            autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $ljid . '> matches the MANUAL rule <' . $trule[0] . '|' . $trule[1] . '>', 3 );
+            $this->criticalcss->log( 'Job id <' . $ljid . '> matches the MANUAL rule <' . $trule[0] . '|' . $trule[1] . '>', 3 );
             return false;
         } elseif ( ! empty( $srule ) ) {
             // Check if an AUTO rule exist.
             if ( $hash === $srule['hash'] && is_file( AO_CCSS_DIR . $srule['file'] ) && 0 != filesize( AO_CCSS_DIR . $srule['file'] ) ) {
                 // Check if job hash matches rule, if the CCSS file exists said file is not empty and return FALSE is so.
-                autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $ljid . '> with hash <' . $hash . '> MATCH the one in rule <' . $trule[0] . '|' . $trule[1] . '>', 3 );
+                $this->criticalcss->log( 'Job id <' . $ljid . '> with hash <' . $hash . '> MATCH the one in rule <' . $trule[0] . '|' . $trule[1] . '>', 3 );
                 return false;
             } else {
                 // Or return the new hash if they differ.
-                autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $ljid . '> with hash <' . $hash . '> DOES NOT MATCH the one in rule <' . $trule[0] . '|' . $trule[1] . '> or rule\'s CCSS file was invalid.', 3 );
+                $this->criticalcss->log( 'Job id <' . $ljid . '> with hash <' . $hash . '> DOES NOT MATCH the one in rule <' . $trule[0] . '|' . $trule[1] . '> or rule\'s CCSS file was invalid.', 3 );
                 return $hash;
             }
         } else {
             // Return the hash for a job that has no rule yet.
-            autoptimizeCriticalCSSCore::ao_ccss_log( 'Job id <' . $ljid . '> with hash <' . $hash . '> has no rule yet', 3 );
+            $this->criticalcss->log( 'Job id <' . $ljid . '> with hash <' . $hash . '> has no rule yet', 3 );
             return $hash;
         }
     }
@@ -440,14 +435,11 @@ class autoptimizeCriticalCSSCron {
     public function ao_ccss_api_generate( $path, $debug, $dcode ) {
         // POST jobs to criticalcss.com and return responses
         // Get key and key status.
-        global $ao_ccss_key;
-        global $ao_ccss_keyst;
-        $key        = $ao_ccss_key;
-        $key_status = $ao_ccss_keyst;
+        $key = $this->criticalcss->get_option( 'key' );
+        $key_status = $this->criticalcss->get_option( 'keyst' );
+        $noptimize = $this->criticalcss->get_option( 'noptimize' );
 
         // Prepare full URL to request.
-        global $ao_ccss_noptimize;
-
         $site_host = get_site_url();
         $site_path = parse_url( $site_host, PHP_URL_PATH );
 
@@ -458,20 +450,20 @@ class autoptimizeCriticalCSSCron {
         // Logic to bind to one domain to avoid site clones of sites would
         // automatically begin spawning requests to criticalcss.com which has
         // a per domain cost.
-        global $ao_ccss_domain;
-        if ( empty( $ao_ccss_domain ) ) {
+        $domain = $this->criticalcss->get_option( 'domain' );
+        if ( empty( $domain ) ) {
             // first request being done, update option to allow future requests are only allowed if from same domain.
             update_option( 'autoptimize_ccss_domain', str_rot13( $site_host ) );
-        } elseif ( trim( $ao_ccss_domain, '\'"' ) !== 'none' && parse_url( $site_host, PHP_URL_HOST ) !== parse_url( $ao_ccss_domain, PHP_URL_HOST ) && apply_filters( 'autoptimize_filter_ccss_bind_domain', true ) ) {
+        } elseif ( trim( $domain, '\'"' ) !== 'none' && parse_url( $site_host, PHP_URL_HOST ) !== parse_url( $domain, PHP_URL_HOST ) && apply_filters( 'autoptimize_filter_ccss_bind_domain', true ) ) {
             // not the same domain, log as error and return without posting to criticalcss.com.
-            autoptimizeCriticalCSSCore::ao_ccss_log( 'Request for domain ' . $site_host . ' does not match bound domain ' . $ao_ccss_domain . ' so not proceeding.', 2 );
+            $this->criticalcss->log( 'Request for domain ' . $site_host . ' does not match bound domain ' . $domain . ' so not proceeding.', 2 );
             return false;
         }
 
         $src_url = $site_host . $path;
 
         // Avoid AO optimizations if required by config or avoid lazyload if lazyload is active in AO.
-        if ( ! empty( $ao_ccss_noptimize ) ) {
+        if ( ! empty( $noptimize ) ) {
             $src_url .= '?ao_noptirocket=1';
         } elseif ( ( class_exists( 'autoptimizeImages', false ) && autoptimizeImages::should_lazyload_wrapper() ) || apply_filters( 'autoptimize_filter_ccss_enforce_nolazy', false ) ) {
             $src_url .= '?ao_nolazy=1';
@@ -486,15 +478,15 @@ class autoptimizeCriticalCSSCron {
         $body['aocssv'] = AO_CCSS_VER;
 
         // Prepare and add viewport size to the body if available.
-        $viewport = autoptimizeCriticalCSSCore::ao_ccss_viewport();
+        $viewport = $this->criticalcss->viewport();
         if ( ! empty( $viewport['w'] ) && ! empty( $viewport['h'] ) ) {
             $body['width']  = $viewport['w'];
             $body['height'] = $viewport['h'];
         }
 
         // Prepare and add forceInclude to the body if available.
-        global $ao_ccss_finclude;
-        $finclude = $this->ao_ccss_finclude( $ao_ccss_finclude );
+        $finclude = $this->criticalcss->get_option( 'finclude' );
+        $finclude = $this->ao_ccss_finclude( $finclude );
         if ( ! empty( $finclude ) ) {
             $body['forceInclude'] = $finclude;
         }
@@ -504,7 +496,7 @@ class autoptimizeCriticalCSSCron {
 
         // Body must be json and log it.
         $body = json_encode( $body );
-        autoptimizeCriticalCSSCore::ao_ccss_log( 'criticalcss.com: POST generate request body is ' . $body, 3 );
+        $this->criticalcss->log( 'criticalcss.com: POST generate request body is ' . $body, 3 );
 
         // Prepare the request.
         $url  = esc_url_raw( AO_CCSS_API . 'generate?aover=' . AO_CCSS_VER );
@@ -533,42 +525,42 @@ class autoptimizeCriticalCSSCron {
             // Workaround criticalcss.com non-RESTful reponses.
             if ( 'JOB_QUEUED' == $body['job']['status'] || 'JOB_ONGOING' == $body['job']['status'] || 'STATUS_JOB_BAD' == $body['job']['status'] ) {
                 // Log successful and return encoded request body.
-                autoptimizeCriticalCSSCore::ao_ccss_log( 'criticalcss.com: POST generate request for path <' . $src_url . '> replied successfully', 3 );
+                $this->criticalcss->log( 'criticalcss.com: POST generate request for path <' . $src_url . '> replied successfully', 3 );
 
                 // This code also means the key is valid, so cache key status for 24h if not already cached.
                 if ( ( ! $key_status || 2 != $key_status ) && $key ) {
                     update_option( 'autoptimize_ccss_keyst', 2 );
-                    autoptimizeCriticalCSSCore::ao_ccss_log( 'criticalcss.com: API key is valid, updating key status', 3 );
+                    $this->criticalcss->log( 'criticalcss.com: API key is valid, updating key status', 3 );
                 }
 
                 // Return the request body.
                 return $body;
             } else {
                 // Log successful requests with invalid reponses.
-                autoptimizeCriticalCSSCore::ao_ccss_log( 'criticalcss.com: POST generate request for path <' . $src_url . '> replied with code <' . $code . '> and an UNKNOWN error condition, body follows...', 2 );
-                autoptimizeCriticalCSSCore::ao_ccss_log( print_r( $body, true ), 2 );
+                $this->criticalcss->log( 'criticalcss.com: POST generate request for path <' . $src_url . '> replied with code <' . $code . '> and an UNKNOWN error condition, body follows...', 2 );
+                $this->criticalcss->log( print_r( $body, true ), 2 );
                 return $body;
             }
         } else {
             // Response code is anything else.
             // Log failed request with a valid response code and return body.
             if ( $code ) {
-                autoptimizeCriticalCSSCore::ao_ccss_log( 'criticalcss.com: POST generate request for path <' . $src_url . '> replied with error code <' . $code . '>, body follows...', 2 );
-                autoptimizeCriticalCSSCore::ao_ccss_log( print_r( $body, true ), 2 );
+                $this->criticalcss->log( 'criticalcss.com: POST generate request for path <' . $src_url . '> replied with error code <' . $code . '>, body follows...', 2 );
+                $this->criticalcss->log( print_r( $body, true ), 2 );
 
                 if ( 401 == $code ) {
                     // If request is unauthorized, also clear key status.
                     update_option( 'autoptimize_ccss_keyst', 1 );
-                    autoptimizeCriticalCSSCore::ao_ccss_log( 'criticalcss.com: API key is invalid, updating key status', 3 );
+                    $this->criticalcss->log( 'criticalcss.com: API key is invalid, updating key status', 3 );
                 }
 
                 // Return the request body.
                 return $body;
             } else {
                 // Log failed request with no response and return false.
-                autoptimizeCriticalCSSCore::ao_ccss_log( 'criticalcss.com: POST generate request for path <' . $src_url . '> has no response, this could be a service timeout', 2 );
+                $this->criticalcss->log( 'criticalcss.com: POST generate request for path <' . $src_url . '> has no response, this could be a service timeout', 2 );
                 if ( is_wp_error( $req ) ) {
-                    autoptimizeCriticalCSSCore::ao_ccss_log( $req->get_error_message(), 2 );
+                    $this->criticalcss->log( $req->get_error_message(), 2 );
                 }
 
                 return false;
@@ -579,8 +571,7 @@ class autoptimizeCriticalCSSCron {
     public function ao_ccss_api_results( $jobid, $debug, $dcode ) {
         // GET jobs from criticalcss.com and return responses
         // Get key.
-        global $ao_ccss_key;
-        $key = $ao_ccss_key;
+        $key = $this->criticalcss->get_option( 'key' );
 
         // Prepare the request.
         $url  = AO_CCSS_API . 'results?resultId=' . $jobid;
@@ -607,36 +598,36 @@ class autoptimizeCriticalCSSCron {
             if ( is_array( $body ) && ( array_key_exists( 'status', $body ) || array_key_exists( 'job', $body ) ) && ( 'JOB_QUEUED' == $body['status'] || 'JOB_ONGOING' == $body['status'] || 'JOB_DONE' == $body['status'] || 'JOB_FAILED' == $body['status'] || 'JOB_UNKNOWN' == $body['status'] || 'STATUS_JOB_BAD' == $body['job']['status'] ) ) {
                 // Workaround criticalcss.com non-RESTful reponses
                 // Log successful and return encoded request body.
-                autoptimizeCriticalCSSCore::ao_ccss_log( 'criticalcss.com: GET results request for remote job id <' . $jobid . '> replied successfully', 3 );
+                $this->criticalcss->log( 'criticalcss.com: GET results request for remote job id <' . $jobid . '> replied successfully', 3 );
                 return $body;
             } elseif ( is_array( $body ) && ( array_key_exists( 'error', $body ) && 'This css no longer exists. Please re-generate it.' == $body['error'] ) ) {
                 // Handle no CSS reply
                 // Log no CSS error and return encoded request body.
-                autoptimizeCriticalCSSCore::ao_ccss_log( 'criticalcss.com: GET results request for remote job id <' . $jobid . '> replied successfully but the CSS for it does not exist anymore', 3 );
+                $this->criticalcss->log( 'criticalcss.com: GET results request for remote job id <' . $jobid . '> replied successfully but the CSS for it does not exist anymore', 3 );
                 return $body;
             } else {
                 // Log failed request and return false.
-                autoptimizeCriticalCSSCore::ao_ccss_log( 'criticalcss.com: GET results request for remote job id <' . $jobid . '> replied with code <' . $code . '> and an UNKNOWN error condition, body follows...', 2 );
-                autoptimizeCriticalCSSCore::ao_ccss_log( print_r( $body, true ), 2 );
+                $this->criticalcss->log( 'criticalcss.com: GET results request for remote job id <' . $jobid . '> replied with code <' . $code . '> and an UNKNOWN error condition, body follows...', 2 );
+                $this->criticalcss->log( print_r( $body, true ), 2 );
                 return false;
             }
         } else {
             // Response code is anything else
             // Log failed request with a valid response code and return body.
             if ( $code ) {
-                autoptimizeCriticalCSSCore::ao_ccss_log( 'criticalcss.com: GET results request for remote job id <' . $jobid . '> replied with error code <' . $code . '>, body follows...', 2 );
-                autoptimizeCriticalCSSCore::ao_ccss_log( print_r( $body, true ), 2 );
+                $this->criticalcss->log( 'criticalcss.com: GET results request for remote job id <' . $jobid . '> replied with error code <' . $code . '>, body follows...', 2 );
+                $this->criticalcss->log( print_r( $body, true ), 2 );
                 if ( 401 == $code ) {
                     // If request is unauthorized, also clear key status.
                     update_option( 'autoptimize_ccss_keyst', 1 );
-                    autoptimizeCriticalCSSCore::ao_ccss_log( 'criticalcss.com: API key is invalid, updating key status', 3 );
+                    $this->criticalcss->log( 'criticalcss.com: API key is invalid, updating key status', 3 );
                 }
 
                 // Return the request body.
                 return $body;
             } else {
                 // Log failed request with no response and return false.
-                autoptimizeCriticalCSSCore::ao_ccss_log( 'criticalcss.com: GET results request for remote job id <' . $jobid . '> has no response, this could be a service timeout', 2 );
+                $this->criticalcss->log( 'criticalcss.com: GET results request for remote job id <' . $jobid . '> has no response, this could be a service timeout', 2 );
                 return false;
             }
         }
@@ -655,31 +646,31 @@ class autoptimizeCriticalCSSCron {
         $filename = false;
         $content  = $ccss;
 
-        if ( autoptimizeCriticalCSSCore::ao_ccss_check_contents( $content ) ) {
+        if ( $this->criticalcss->check_contents( $content ) ) {
             // Sanitize content, set filename and try to save file.
             $file     = AO_CCSS_DIR . 'ccss_' . md5( $ccss . $target[1] ) . $rmark . '.css';
             $status   = file_put_contents( $file, $content, LOCK_EX );
             $filename = pathinfo( $file, PATHINFO_BASENAME );
-            autoptimizeCriticalCSSCore::ao_ccss_log( 'Critical CSS file for the rule <' . $target[0] . '|' . $target[1] . '> was saved as <' . $filename . '>, size in bytes is <' . $status . '>', 3 );
+            $this->criticalcss->log( 'Critical CSS file for the rule <' . $target[0] . '|' . $target[1] . '> was saved as <' . $filename . '>, size in bytes is <' . $status . '>', 3 );
 
             if ( ! $status ) {
                 // If file has not been saved, reset filename.
-                autoptimizeCriticalCSSCore::ao_ccss_log( 'Critical CSS file <' . $filename . '> could not be not saved', 2 );
+                $this->criticalcss->log( 'Critical CSS file <' . $filename . '> could not be not saved', 2 );
                 $filename = false;
                 return $filename;
             }
         } else {
-            autoptimizeCriticalCSSCore::ao_ccss_log( 'Critical CSS received did not pass content check', 2 );
+            $this->criticalcss->( 'Critical CSS received did not pass content check', 2 );
             return $filename;
         }
 
         // Remove old critical CSS if a previous one existed in the rule and if that file exists in filesystem
         // NOTE: out of scope critical CSS file removal (issue #5)
         // Attach required arrays.
-        global $ao_ccss_rules;
+        $rules = $this->criticalcss->get_option( 'rules' );
 
         // Prepare rule variables.
-        $srule   = $ao_ccss_rules[ $target[0] ][ $target[1] ];
+        $srule   = $rules[ $target[0] ][ $target[1] ];
         $oldfile = $srule['file'];
 
         if ( $oldfile && $oldfile !== $filename ) {
@@ -687,7 +678,7 @@ class autoptimizeCriticalCSSCron {
             if ( file_exists( $delfile ) ) {
                 $unlinkst = unlink( $delfile );
                 if ( $unlinkst ) {
-                    autoptimizeCriticalCSSCore::ao_ccss_log( 'A previous critical CSS file <' . $oldfile . '> was removed for the rule <' . $target[0] . '|' . $target[1] . '>', 3 );
+                    $this->criticalcss->log( 'A previous critical CSS file <' . $oldfile . '> was removed for the rule <' . $target[0] . '|' . $target[1] . '>', 3 );
                 }
             }
         }
@@ -699,11 +690,11 @@ class autoptimizeCriticalCSSCron {
     public function ao_ccss_rule_update( $ljid, $srule, $file, $hash ) {
         // Update or create a rule
         // Attach required arrays.
-        global $ao_ccss_rules;
+        $rules = $this->criticalcss->get_option( 'rules' );
 
         // Prepare rule variables.
         $trule  = explode( '|', $srule );
-        $rule   = $ao_ccss_rules[ $trule[0] ][ $trule[1] ];
+        $rule   = $rules[ $trule[0] ][ $trule[1] ];
         $action = false;
         $rtype  = '';
 
@@ -736,18 +727,18 @@ class autoptimizeCriticalCSSCron {
                 $rtype        = 'AUTO';
             } else {
                 // Log that no rule was created.
-                autoptimizeCriticalCSSCore::ao_ccss_log( 'Exception, no AUTO rule created', 3 );
+                $this->criticalcss->log( 'Exception, no AUTO rule created', 3 );
             }
         }
 
         if ( $action ) {
             // If a rule creation/update is required, persist updated rules object.
-            $ao_ccss_rules[ $trule[0] ][ $trule[1] ] = $rule;
-            $ao_ccss_rules_raw                       = json_encode( $ao_ccss_rules );
-            update_option( 'autoptimize_ccss_rules', $ao_ccss_rules_raw );
-            autoptimizeCriticalCSSCore::ao_ccss_log( 'Target rule <' . $srule . '> of type <' . $rtype . '> was ' . $action . ' for job id <' . $ljid . '>', 3 );
+            $rules[ $trule[0] ][ $trule[1] ] = $rule;
+            $rules_raw = json_encode( $rules );
+            update_option( 'autoptimize_ccss_rules', $rules_raw );
+            $this->criticalcss->log( 'Target rule <' . $srule . '> of type <' . $rtype . '> was ' . $action . ' for job id <' . $ljid . '>', 3 );
         } else {
-            autoptimizeCriticalCSSCore::ao_ccss_log( 'No rule action required', 3 );
+            $this->criticalcss->log( 'No rule action required', 3 );
         }
     }
 
@@ -811,10 +802,11 @@ class autoptimizeCriticalCSSCron {
         }
 
         // Queue cleaning.
-        global $ao_ccss_queue;
+        $queue = $this->criticalcss->get_option( 'queue' );
+
         $queue_purge_threshold = 100;
         $queue_purge_age       = 24 * 60 * 60;
-        $queue_length          = count( $ao_ccss_queue );
+        $queue_length          = count( $queue );
         $timestamp_yesterday   = microtime( true ) - $queue_purge_age;
         $remove_old_new        = false;
         $queue_altered         = false;
@@ -823,23 +815,23 @@ class autoptimizeCriticalCSSCron {
             $remove_old_new = true;
         }
 
-        foreach ( $ao_ccss_queue as $path => $job ) {
+        foreach ( $queue as $path => $job ) {
             if ( ( $remove_old_new && 'NEW' == $job['jqstat'] && $job['jctime'] < $timestamp_yesterday ) || in_array( $job['jqstat'], array( 'JOB_FAILED', 'STATUS_JOB_BAD', 'NO_CSS', 'NO_RESPONSE' ) ) ) {
-                unset( $ao_ccss_queue[ $path ] );
+                unset( $queue[ $path ] );
                 $queue_altered = true;
             }
         }
 
         // save queue to options!
         if ( $queue_altered ) {
-            $ao_ccss_queue_raw = json_encode( $ao_ccss_queue );
-            update_option( 'autoptimize_ccss_queue', $ao_ccss_queue_raw, false );
-            autoptimizeCriticalCSSCore::ao_ccss_log( 'Queue cleaning done.', 3 );
+            $queue_raw = json_encode( $queue );
+            update_option( 'autoptimize_ccss_queue', $queue_raw, false );
+            $this->criticalcss->log( 'Queue cleaning done.', 3 );
         }
 
         // re-check key if invalid.
-        global $ao_ccss_keyst;
-        if ( 1 == $ao_ccss_keyst ) {
+        $keyst = $this->criticalcss->get_option( 'keyst' );
+        if ( 1 == $keyst ) {
             $this->ao_ccss_api_generate( '', '', '' );
         }
     }

--- a/classes/autoptimizeCriticalCSSCron.php
+++ b/classes/autoptimizeCriticalCSSCron.php
@@ -736,6 +736,7 @@ class autoptimizeCriticalCSSCron {
             $rules[ $trule[0] ][ $trule[1] ] = $rule;
             $rules_raw = json_encode( $rules );
             update_option( 'autoptimize_ccss_rules', $rules_raw );
+            $this->criticalcss->flush_options();
             $this->criticalcss->log( 'Target rule <' . $srule . '> of type <' . $rtype . '> was ' . $action . ' for job id <' . $ljid . '>', 3 );
         } else {
             $this->criticalcss->log( 'No rule action required', 3 );

--- a/classes/autoptimizeCriticalCSSEnqueue.php
+++ b/classes/autoptimizeCriticalCSSEnqueue.php
@@ -210,7 +210,7 @@ class autoptimizeCriticalCSSEnqueue {
     public function ao_ccss_get_type() {
         // Get the type of a page
         // Attach the conditional tags array.
-        $types = $this->criticalcss->get_option( 'types' );
+        $types = $this->criticalcss->get_types();
         $forcepath = $this->criticalcss->get_option( 'forcepath' );
 
         // By default, a page type is false.

--- a/classes/autoptimizeCriticalCSSEnqueue.php
+++ b/classes/autoptimizeCriticalCSSEnqueue.php
@@ -8,20 +8,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class autoptimizeCriticalCSSEnqueue {
-    public function __construct()
-    {
-        // fetch all options at once and populate them individually explicitely as globals.
-        $all_options = autoptimizeCriticalCSSBase::fetch_options();
-        foreach ( $all_options as $_option => $_value ) {
-            global ${$_option};
-            ${$_option} = $_value;
-        }
+    public function __construct() {
+        $this->criticalcss = autoptimize()->criticalcss();
     }
 
-    public static function ao_ccss_enqueue( $hash = '', $path = '', $type = 'is_page' ) {
-        $self = new self();
+    public function ao_ccss_enqueue( $hash = '', $path = '', $type = 'is_page' ) {
         // Get key status.
-        $key = autoptimizeCriticalCSSCore::ao_ccss_key_status( false );
+        $key = $this->criticalcss->key_status( false );
 
         // Queue is available to anyone...
         $enqueue = true;
@@ -29,22 +22,22 @@ class autoptimizeCriticalCSSEnqueue {
         // ... which are not the ones below.
         if ( 'nokey' == $key['status'] || 'invalid' == $key['status'] ) {
             $enqueue = false;
-            autoptimizeCriticalCSSCore::ao_ccss_log( "Job queuing is not available: no valid API key found.", 3 );
+            $this->criticalcss->log( "Job queuing is not available: no valid API key found.", 3 );
         } elseif ( ! empty( $hash ) && ( is_user_logged_in() || is_feed() || is_404() || ( defined( 'DOING_AJAX' ) && DOING_AJAX ) || $self->ao_ccss_ua() || false === apply_filters( 'autoptimize_filter_ccss_enqueue_should_enqueue', true ) ) ) {
             $enqueue = false;
-            autoptimizeCriticalCSSCore::ao_ccss_log( "Job queuing is not available for WordPress's logged in users, feeds, error pages, ajax calls or calls from criticalcss.com itself.", 3 );
+            $this->criticalcss->log( "Job queuing is not available for WordPress's logged in users, feeds, error pages, ajax calls or calls from criticalcss.com itself.", 3 );
         } elseif ( empty( $hash ) && empty( $path ) || ( ( 'is_single' !== $type ) && ( 'is_page' !== $type ) ) ) {
             $enqueue = false;
-            autoptimizeCriticalCSSCore::ao_ccss_log( "Forced job queuing failed, no path or not right type", 3 );            
+            $this->criticalcss->log( "Forced job queuing failed, no path or not right type", 3 );
         }
 
         if ( $enqueue ) {
             // Continue if queue is available
             // Attach required arrays/ vars.
-            global $ao_ccss_rules;
-            global $ao_ccss_queue_raw;
-            global $ao_ccss_queue;
-            global $ao_ccss_forcepath;
+            $rules = $this->criticalcss->get_option( 'rules' );
+            $queue_raw = $this->criticalcss->get_option( 'queue_raw' );
+            $queue = $this->criticalcss->get_option( 'queue' );
+            $forcepath = $this->criticalcss->get_option( 'forcepath' );
 
             // Get request path and page type, and initialize the queue update flag.
             if ( ! empty( $hash ) ) {
@@ -78,11 +71,11 @@ class autoptimizeCriticalCSSEnqueue {
             $queue_update    = false;
 
             // Match for paths in rules.
-            foreach ( $ao_ccss_rules['paths'] as $path => $props ) {
+            foreach ( $rules['paths'] as $path => $props ) {
 
                 // Prepare rule target and log.
                 $target_rule = 'paths|' . $path;
-                autoptimizeCriticalCSSCore::ao_ccss_log( 'Qualifying path <' . $req_path . '> for job submission by rule <' . $target_rule . '>', 3 );
+                $this->criticalcss->log( 'Qualifying path <' . $req_path . '> for job submission by rule <' . $target_rule . '>', 3 );
 
                 // Path match
                 // -> exact match needed for AUTO rules
@@ -92,7 +85,7 @@ class autoptimizeCriticalCSSEnqueue {
                     // There's a path match in the rule, so job QUALIFIES with a path rule match.
                     $job_qualify     = true;
                     $rule_properties = $props;
-                    autoptimizeCriticalCSSCore::ao_ccss_log( 'Path <' . $req_path . '> QUALIFIED for job submission by rule <' . $target_rule . '>', 3 );
+                    $this->criticalcss->log( 'Path <' . $req_path . '> QUALIFIED for job submission by rule <' . $target_rule . '>', 3 );
 
                     // Stop processing other path rules.
                     break;
@@ -100,19 +93,19 @@ class autoptimizeCriticalCSSEnqueue {
             }
 
             // Match for types in rules if no path rule matches and if we're not enforcing paths.
-            if ( '' !== $hash && ! $job_qualify && ( ! $ao_ccss_forcepath || ! in_array( $req_type, apply_filters( 'autoptimize_filter_ccss_coreenqueue_forcepathfortype', array( 'is_page' ) ) ) || ! apply_filters( 'autoptimize_filter_ccss_coreenqueue_ignorealltypes', false ) ) ) {
-                foreach ( $ao_ccss_rules['types'] as $type => $props ) {
+            if ( '' !== $hash && ! $job_qualify && ( ! $forcepath || ! in_array( $req_type, apply_filters( 'autoptimize_filter_ccss_coreenqueue_forcepathfortype', array( 'is_page' ) ) ) || ! apply_filters( 'autoptimize_filter_ccss_coreenqueue_ignorealltypes', false ) ) ) {
+                foreach ( $rules['types'] as $type => $props ) {
 
                     // Prepare rule target and log.
                     $target_rule = 'types|' . $type;
-                    autoptimizeCriticalCSSCore::ao_ccss_log( 'Qualifying page type <' . $req_type . '> on path <' . $req_path . '> for job submission by rule <' . $target_rule . '>', 3 );
+                    $this->criticalcss->log( 'Qualifying page type <' . $req_type . '> on path <' . $req_path . '> for job submission by rule <' . $target_rule . '>', 3 );
 
                     if ( $req_type == $type ) {
                         // Type match.
                         // There's a type match in the rule, so job QUALIFIES with a type rule match.
                         $job_qualify     = true;
                         $rule_properties = $props;
-                        autoptimizeCriticalCSSCore::ao_ccss_log( 'Page type <' . $req_type . '> on path <' . $req_path . '> QUALIFIED for job submission by rule <' . $target_rule . '>', 3 );
+                        $this->criticalcss->log( 'Page type <' . $req_type . '> on path <' . $req_path . '> QUALIFIED for job submission by rule <' . $target_rule . '>', 3 );
 
                         // Stop processing other type rules.
                         break;
@@ -123,7 +116,7 @@ class autoptimizeCriticalCSSEnqueue {
             if ( $job_qualify && ( ( false == $rule_properties['hash'] && false != $rule_properties['file'] ) || strpos( $req_type, 'template_' ) !== false ) ) {
                 // If job qualifies but rule hash is false and file isn't false (MANUAL rule) or if template, job does not qualify despite what previous evaluations says.
                 $job_qualify = false;
-                autoptimizeCriticalCSSCore::ao_ccss_log( 'Job submission DISQUALIFIED by MANUAL rule <' . $target_rule . '> with hash <' . $rule_properties['hash'] . '> and file <' . $rule_properties['file'] . '>', 3 );
+                $this->criticalcss->log( 'Job submission DISQUALIFIED by MANUAL rule <' . $target_rule . '> with hash <' . $rule_properties['hash'] . '> and file <' . $rule_properties['file'] . '>', 3 );
             } elseif ( ! $job_qualify && empty( $rule_properties ) ) {
                 // But if job does not qualify and rule properties are set, job qualifies as there is no matching rule for it yet
                 // Fill-in the new target rule.
@@ -132,7 +125,7 @@ class autoptimizeCriticalCSSEnqueue {
                 // Should we switch to path-base AUTO-rules? Conditions:
                 // 1. forcepath option has to be enabled (off by default)
                 // 2. request type should be (by default, but filterable) one of is_page (removed for now: woo_is_product or woo_is_product_category).
-                if ( ( $ao_ccss_forcepath && in_array( $req_type, apply_filters( 'autoptimize_filter_ccss_coreenqueue_forcepathfortype', array( 'is_page' ) ) ) ) || apply_filters( 'autoptimize_filter_ccss_coreenqueue_ignorealltypes', false ) || empty( $hash )) {
+                if ( ( $forcepath && in_array( $req_type, apply_filters( 'autoptimize_filter_ccss_coreenqueue_forcepathfortype', array( 'is_page' ) ) ) ) || apply_filters( 'autoptimize_filter_ccss_coreenqueue_ignorealltypes', false ) || empty( $hash )) {
                     if ( '/' !== $req_path ) {
                         $target_rule = 'paths|' . $req_path;
                     } else {
@@ -142,18 +135,18 @@ class autoptimizeCriticalCSSEnqueue {
                 } else {
                     $target_rule = 'types|' . $req_type;
                 }
-                autoptimizeCriticalCSSCore::ao_ccss_log( 'Job submission QUALIFIED by MISSING rule for page type <' . $req_type . '> on path <' . $req_path . '>, new rule target is <' . $target_rule . '>', 3 );
+                $this->criticalcss->log( 'Job submission QUALIFIED by MISSING rule for page type <' . $req_type . '> on path <' . $req_path . '>, new rule target is <' . $target_rule . '>', 3 );
             } else {
                 // Or just log a job qualified by a matching rule.
-                autoptimizeCriticalCSSCore::ao_ccss_log( 'Job submission QUALIFIED by AUTO rule <' . $target_rule . '> with hash <' . $rule_properties['hash'] . '> and file <' . $rule_properties['file'] . '>', 3 );
+                $this->criticalcss->log( 'Job submission QUALIFIED by AUTO rule <' . $target_rule . '> with hash <' . $rule_properties['hash'] . '> and file <' . $rule_properties['file'] . '>', 3 );
             }
 
             // Submit job.
             if ( $job_qualify ) {
-                if ( ! array_key_exists( $req_path, $ao_ccss_queue ) ) {
+                if ( ! array_key_exists( $req_path, $queue ) ) {
                     // This is a NEW job
                     // Merge job into the queue.
-                    $ao_ccss_queue[ $req_path ] = $self->ao_ccss_define_job(
+                    $queue[ $req_path ] = $self->ao_ccss_define_job(
                         $req_path,
                         $target_rule,
                         $req_type,
@@ -169,30 +162,30 @@ class autoptimizeCriticalCSSEnqueue {
                 } else {
                     // This is an existing job
                     // The job is still NEW, most likely this is extra CSS file for the same page that needs a hash.
-                    if ( 'NEW' == $ao_ccss_queue[ $req_path ]['jqstat'] ) {
+                    if ( 'NEW' == $queue[ $req_path ]['jqstat'] ) {
                         // Add hash if it's not already in the job.
-                        if ( ! in_array( $hash, $ao_ccss_queue[ $req_path ]['hashes'] ) ) {
+                        if ( ! in_array( $hash, $queue[ $req_path ]['hashes'] ) ) {
                             // Push new hash to its array and update flag.
-                            $queue_update = array_push( $ao_ccss_queue[ $req_path ]['hashes'], $hash );
+                            $queue_update = array_push( $queue[ $req_path ]['hashes'], $hash );
 
                             // Log job update.
-                            autoptimizeCriticalCSSCore::ao_ccss_log( 'Hashes UPDATED on local job id <' . $ao_ccss_queue[ $req_path ]['ljid'] . '>, job status NEW, target rule <' . $ao_ccss_queue[ $req_path ]['rtarget'] . '>, hash added: ' . $hash, 3 );
+                            $this->criticalcss->log( 'Hashes UPDATED on local job id <' . $queue[ $req_path ]['ljid'] . '>, job status NEW, target rule <' . $queue[ $req_path ]['rtarget'] . '>, hash added: ' . $hash, 3 );
 
                             // Return from here as the hash array is already updated.
                             return true;
                         }
-                    } elseif ( 'NEW' != $ao_ccss_queue[ $req_path ]['jqstat'] && 'JOB_QUEUED' != $ao_ccss_queue[ $req_path ]['jqstat'] && 'JOB_ONGOING' != $ao_ccss_queue[ $req_path ]['jqstat'] ) {
+                    } elseif ( 'NEW' != $queue[ $req_path ]['jqstat'] && 'JOB_QUEUED' != $queue[ $req_path ]['jqstat'] && 'JOB_ONGOING' != $queue[ $req_path ]['jqstat'] ) {
                         // Allow requeuing jobs that are not NEW, JOB_QUEUED or JOB_ONGOING
                         // Merge new job keeping some previous job values.
-                        $ao_ccss_queue[ $req_path ] = $self->ao_ccss_define_job(
+                        $queue[ $req_path ] = $self->ao_ccss_define_job(
                             $req_path,
                             $target_rule,
                             $req_type,
                             $hash,
-                            $ao_ccss_queue[ $req_path ]['file'],
-                            $ao_ccss_queue[ $req_path ]['jid'],
-                            $ao_ccss_queue[ $req_path ]['jrstat'],
-                            $ao_ccss_queue[ $req_path ]['jvstat'],
+                            $queue[ $req_path ]['file'],
+                            $queue[ $req_path ]['jid'],
+                            $queue[ $req_path ]['jrstat'],
+                            $queue[ $req_path ]['jvstat'],
                             false
                         );
                         // Set update flag.
@@ -202,12 +195,12 @@ class autoptimizeCriticalCSSEnqueue {
 
                 if ( $queue_update ) {
                     // Persist the job to the queue and return.
-                    $ao_ccss_queue_raw = json_encode( $ao_ccss_queue );
-                    update_option( 'autoptimize_ccss_queue', $ao_ccss_queue_raw, false );
+                    $queue_raw = json_encode( $queue );
+                    update_option( 'autoptimize_ccss_queue', $queue_raw, false );
                     return true;
                 } else {
                     // Or just return false if no job was added.
-                    autoptimizeCriticalCSSCore::ao_ccss_log( 'A job for path <' . $req_path . '> already exist with NEW or PENDING status, skipping job creation', 3 );
+                    $this->criticalcss->log( 'A job for path <' . $req_path . '> already exist with NEW or PENDING status, skipping job creation', 3 );
                     return false;
                 }
             }
@@ -217,14 +210,14 @@ class autoptimizeCriticalCSSEnqueue {
     public function ao_ccss_get_type() {
         // Get the type of a page
         // Attach the conditional tags array.
-        global $ao_ccss_types;
-        global $ao_ccss_forcepath;
+        $types = $this->criticalcss->get_option( 'types' );
+        $forcepath = $this->criticalcss->get_option( 'forcepath' );
 
         // By default, a page type is false.
         $page_type = false;
 
         // Iterates over the array to match a type.
-        foreach ( $ao_ccss_types as $type ) {
+        foreach ( $types as $type ) {
             if ( is_404() ) {
                 $page_type = 'is_404';
                 break;
@@ -232,13 +225,13 @@ class autoptimizeCriticalCSSEnqueue {
                 // identify frontpage immediately to avoid it also matching a CPT or template.
                 $page_type = 'is_front_page';
                 break;
-            } elseif ( strpos( $type, 'custom_post_' ) !== false && ( ! $ao_ccss_forcepath || ! is_page() ) ) {
+            } elseif ( strpos( $type, 'custom_post_' ) !== false && ( ! $forcepath || ! is_page() ) ) {
                 // Match custom post types and not page or page not forced to path-based.
                 if ( get_post_type( get_the_ID() ) === substr( $type, 12 ) ) {
                     $page_type = $type;
                     break;
                 }
-            } elseif ( strpos( $type, 'template_' ) !== false && ( ! $ao_ccss_forcepath || ! is_page() ) ) {
+            } elseif ( strpos( $type, 'template_' ) !== false && ( ! $forcepath || ! is_page() ) ) {
                 // Match templates if not page or if page is not forced to path-based.
                 if ( is_page_template( substr( $type, 9 ) ) ) {
                     $page_type = $type;
@@ -287,7 +280,7 @@ class autoptimizeCriticalCSSEnqueue {
         }
 
         // Log job creation.
-        autoptimizeCriticalCSSCore::ao_ccss_log( 'Job ' . $operation . ' with local job id <' . $path['ljid'] . '> for target rule <' . $target . '>', 3 );
+        $this->criticalcss->log( 'Job ' . $operation . ' with local job id <' . $path['ljid'] . '> for target rule <' . $target . '>', 3 );
 
         return $path;
     }

--- a/classes/autoptimizeCriticalCSSEnqueue.php
+++ b/classes/autoptimizeCriticalCSSEnqueue.php
@@ -200,6 +200,7 @@ class autoptimizeCriticalCSSEnqueue {
                 // Persist the job to the queue and return.
                 $queue_raw = json_encode( $queue );
                 update_option( 'autoptimize_ccss_queue', $queue_raw, false );
+                $this->criticalcss->flush_options();
                 return true;
             } else {
                 // Or just return false if no job was added.

--- a/classes/autoptimizeCriticalCSSEnqueue.php
+++ b/classes/autoptimizeCriticalCSSEnqueue.php
@@ -31,178 +31,180 @@ class autoptimizeCriticalCSSEnqueue {
             $this->criticalcss->log( "Forced job queuing failed, no path or not right type", 3 );
         }
 
-        if ( $enqueue ) {
-            // Continue if queue is available
-            // Attach required arrays/ vars.
-            $rules = $this->criticalcss->get_option( 'rules' );
-            $queue_raw = $this->criticalcss->get_option( 'queue_raw' );
-            $queue = $this->criticalcss->get_option( 'queue' );
-            $forcepath = $this->criticalcss->get_option( 'forcepath' );
+        if ( ! $enqueue ) {
+            return;
+        }
 
-            // Get request path and page type, and initialize the queue update flag.
-            if ( ! empty( $hash ) ) {
-                $req_orig = $_SERVER['REQUEST_URI'];
-                $req_type = $this->ao_ccss_get_type();
-            } elseif ( ! empty( $path ) ) {
-                $req_orig = $path;
-                if ( $path === '/' ) {
-                    $req_type = 'is_front_page';
-                } else {
-                    $req_type = $type;
-                }
+        // Continue if queue is available
+        // Attach required arrays/ vars.
+        $rules = $this->criticalcss->get_option( 'rules' );
+        $queue_raw = $this->criticalcss->get_option( 'queue_raw' );
+        $queue = $this->criticalcss->get_option( 'queue' );
+        $forcepath = $this->criticalcss->get_option( 'forcepath' );
+
+        // Get request path and page type, and initialize the queue update flag.
+        if ( ! empty( $hash ) ) {
+            $req_orig = $_SERVER['REQUEST_URI'];
+            $req_type = $this->ao_ccss_get_type();
+        } elseif ( ! empty( $path ) ) {
+            $req_orig = $path;
+            if ( $path === '/' ) {
+                $req_type = 'is_front_page';
+            } else {
+                $req_type = $type;
             }
-            $req_path = strtok( $req_orig, '?' );
+        }
+        $req_path = strtok( $req_orig, '?' );
 
-            // Check if we have a lang param. we need to keep as WPML can switch languages based on that
-            // and that includes RTL -> LTR so diff. structure, so rules would be RTL vs LTR
-            // but this needs changes in the structur of the rule object so off by default for now
-            // as now this will simply result in conditional rules being overwritten.
-            if ( apply_filters( 'autoptimize_filter_ccss_coreenqueue_honor_lang', false ) && strpos( $req_orig, 'lang=' ) !== false ) {
-                $req_params = strtok( '?' );
-                parse_str( $req_params, $req_params_arr );
-                if ( array_key_exists( 'lang', $req_params_arr ) && !empty( $req_params_arr['lang'] ) ) {
-                    $req_path .= '?lang=' . $req_params_arr['lang'];
-                }
+        // Check if we have a lang param. we need to keep as WPML can switch languages based on that
+        // and that includes RTL -> LTR so diff. structure, so rules would be RTL vs LTR
+        // but this needs changes in the structur of the rule object so off by default for now
+        // as now this will simply result in conditional rules being overwritten.
+        if ( apply_filters( 'autoptimize_filter_ccss_coreenqueue_honor_lang', false ) && strpos( $req_orig, 'lang=' ) !== false ) {
+            $req_params = strtok( '?' );
+            parse_str( $req_params, $req_params_arr );
+            if ( array_key_exists( 'lang', $req_params_arr ) && !empty( $req_params_arr['lang'] ) ) {
+                $req_path .= '?lang=' . $req_params_arr['lang'];
             }
+        }
 
-            $job_qualify     = false;
-            $target_rule     = false;
-            $rule_properties = false;
-            $queue_update    = false;
+        $job_qualify     = false;
+        $target_rule     = false;
+        $rule_properties = false;
+        $queue_update    = false;
 
-            // Match for paths in rules.
-            foreach ( $rules['paths'] as $path => $props ) {
+        // Match for paths in rules.
+        foreach ( $rules['paths'] as $path => $props ) {
+
+            // Prepare rule target and log.
+            $target_rule = 'paths|' . $path;
+            $this->criticalcss->log( 'Qualifying path <' . $req_path . '> for job submission by rule <' . $target_rule . '>', 3 );
+
+            // Path match
+            // -> exact match needed for AUTO rules
+            // -> partial match OK for MANUAL rules (which have empty hash and a file with CCSS).
+            if ( $path === $req_path || ( false == $props['hash'] && false != $props['file'] && preg_match( '|' . $path . '|', $req_path ) ) ) {
+
+                // There's a path match in the rule, so job QUALIFIES with a path rule match.
+                $job_qualify     = true;
+                $rule_properties = $props;
+                $this->criticalcss->log( 'Path <' . $req_path . '> QUALIFIED for job submission by rule <' . $target_rule . '>', 3 );
+
+                // Stop processing other path rules.
+                break;
+            }
+        }
+
+        // Match for types in rules if no path rule matches and if we're not enforcing paths.
+        if ( '' !== $hash && ! $job_qualify && ( ! $forcepath || ! in_array( $req_type, apply_filters( 'autoptimize_filter_ccss_coreenqueue_forcepathfortype', array( 'is_page' ) ) ) || ! apply_filters( 'autoptimize_filter_ccss_coreenqueue_ignorealltypes', false ) ) ) {
+            foreach ( $rules['types'] as $type => $props ) {
 
                 // Prepare rule target and log.
-                $target_rule = 'paths|' . $path;
-                $this->criticalcss->log( 'Qualifying path <' . $req_path . '> for job submission by rule <' . $target_rule . '>', 3 );
+                $target_rule = 'types|' . $type;
+                $this->criticalcss->log( 'Qualifying page type <' . $req_type . '> on path <' . $req_path . '> for job submission by rule <' . $target_rule . '>', 3 );
 
-                // Path match
-                // -> exact match needed for AUTO rules
-                // -> partial match OK for MANUAL rules (which have empty hash and a file with CCSS).
-                if ( $path === $req_path || ( false == $props['hash'] && false != $props['file'] && preg_match( '|' . $path . '|', $req_path ) ) ) {
-
-                    // There's a path match in the rule, so job QUALIFIES with a path rule match.
+                if ( $req_type == $type ) {
+                    // Type match.
+                    // There's a type match in the rule, so job QUALIFIES with a type rule match.
                     $job_qualify     = true;
                     $rule_properties = $props;
-                    $this->criticalcss->log( 'Path <' . $req_path . '> QUALIFIED for job submission by rule <' . $target_rule . '>', 3 );
+                    $this->criticalcss->log( 'Page type <' . $req_type . '> on path <' . $req_path . '> QUALIFIED for job submission by rule <' . $target_rule . '>', 3 );
 
-                    // Stop processing other path rules.
+                    // Stop processing other type rules.
                     break;
                 }
             }
+        }
 
-            // Match for types in rules if no path rule matches and if we're not enforcing paths.
-            if ( '' !== $hash && ! $job_qualify && ( ! $forcepath || ! in_array( $req_type, apply_filters( 'autoptimize_filter_ccss_coreenqueue_forcepathfortype', array( 'is_page' ) ) ) || ! apply_filters( 'autoptimize_filter_ccss_coreenqueue_ignorealltypes', false ) ) ) {
-                foreach ( $rules['types'] as $type => $props ) {
+        if ( $job_qualify && ( ( false == $rule_properties['hash'] && false != $rule_properties['file'] ) || strpos( $req_type, 'template_' ) !== false ) ) {
+            // If job qualifies but rule hash is false and file isn't false (MANUAL rule) or if template, job does not qualify despite what previous evaluations says.
+            $job_qualify = false;
+            $this->criticalcss->log( 'Job submission DISQUALIFIED by MANUAL rule <' . $target_rule . '> with hash <' . $rule_properties['hash'] . '> and file <' . $rule_properties['file'] . '>', 3 );
+        } elseif ( ! $job_qualify && empty( $rule_properties ) ) {
+            // But if job does not qualify and rule properties are set, job qualifies as there is no matching rule for it yet
+            // Fill-in the new target rule.
+            $job_qualify = true;
 
-                    // Prepare rule target and log.
-                    $target_rule = 'types|' . $type;
-                    $this->criticalcss->log( 'Qualifying page type <' . $req_type . '> on path <' . $req_path . '> for job submission by rule <' . $target_rule . '>', 3 );
-
-                    if ( $req_type == $type ) {
-                        // Type match.
-                        // There's a type match in the rule, so job QUALIFIES with a type rule match.
-                        $job_qualify     = true;
-                        $rule_properties = $props;
-                        $this->criticalcss->log( 'Page type <' . $req_type . '> on path <' . $req_path . '> QUALIFIED for job submission by rule <' . $target_rule . '>', 3 );
-
-                        // Stop processing other type rules.
-                        break;
-                    }
-                }
-            }
-
-            if ( $job_qualify && ( ( false == $rule_properties['hash'] && false != $rule_properties['file'] ) || strpos( $req_type, 'template_' ) !== false ) ) {
-                // If job qualifies but rule hash is false and file isn't false (MANUAL rule) or if template, job does not qualify despite what previous evaluations says.
-                $job_qualify = false;
-                $this->criticalcss->log( 'Job submission DISQUALIFIED by MANUAL rule <' . $target_rule . '> with hash <' . $rule_properties['hash'] . '> and file <' . $rule_properties['file'] . '>', 3 );
-            } elseif ( ! $job_qualify && empty( $rule_properties ) ) {
-                // But if job does not qualify and rule properties are set, job qualifies as there is no matching rule for it yet
-                // Fill-in the new target rule.
-                $job_qualify = true;
-
-                // Should we switch to path-base AUTO-rules? Conditions:
-                // 1. forcepath option has to be enabled (off by default)
-                // 2. request type should be (by default, but filterable) one of is_page (removed for now: woo_is_product or woo_is_product_category).
-                if ( ( $forcepath && in_array( $req_type, apply_filters( 'autoptimize_filter_ccss_coreenqueue_forcepathfortype', array( 'is_page' ) ) ) ) || apply_filters( 'autoptimize_filter_ccss_coreenqueue_ignorealltypes', false ) || empty( $hash )) {
-                    if ( '/' !== $req_path ) {
-                        $target_rule = 'paths|' . $req_path;
-                    } else {
-                        // Exception; we don't want a path-based rule for "/" as that messes things up, hard-switch this to a type-based is_front_page rule.
-                        $target_rule = 'types|' . 'is_front_page';
-                    }
+            // Should we switch to path-base AUTO-rules? Conditions:
+            // 1. forcepath option has to be enabled (off by default)
+            // 2. request type should be (by default, but filterable) one of is_page (removed for now: woo_is_product or woo_is_product_category).
+            if ( ( $forcepath && in_array( $req_type, apply_filters( 'autoptimize_filter_ccss_coreenqueue_forcepathfortype', array( 'is_page' ) ) ) ) || apply_filters( 'autoptimize_filter_ccss_coreenqueue_ignorealltypes', false ) || empty( $hash )) {
+                if ( '/' !== $req_path ) {
+                    $target_rule = 'paths|' . $req_path;
                 } else {
-                    $target_rule = 'types|' . $req_type;
+                    // Exception; we don't want a path-based rule for "/" as that messes things up, hard-switch this to a type-based is_front_page rule.
+                    $target_rule = 'types|' . 'is_front_page';
                 }
-                $this->criticalcss->log( 'Job submission QUALIFIED by MISSING rule for page type <' . $req_type . '> on path <' . $req_path . '>, new rule target is <' . $target_rule . '>', 3 );
             } else {
-                // Or just log a job qualified by a matching rule.
-                $this->criticalcss->log( 'Job submission QUALIFIED by AUTO rule <' . $target_rule . '> with hash <' . $rule_properties['hash'] . '> and file <' . $rule_properties['file'] . '>', 3 );
+                $target_rule = 'types|' . $req_type;
             }
+            $this->criticalcss->log( 'Job submission QUALIFIED by MISSING rule for page type <' . $req_type . '> on path <' . $req_path . '>, new rule target is <' . $target_rule . '>', 3 );
+        } else {
+            // Or just log a job qualified by a matching rule.
+            $this->criticalcss->log( 'Job submission QUALIFIED by AUTO rule <' . $target_rule . '> with hash <' . $rule_properties['hash'] . '> and file <' . $rule_properties['file'] . '>', 3 );
+        }
 
-            // Submit job.
-            if ( $job_qualify ) {
-                if ( ! array_key_exists( $req_path, $queue ) ) {
-                    // This is a NEW job
-                    // Merge job into the queue.
+        // Submit job.
+        if ( $job_qualify ) {
+            if ( ! array_key_exists( $req_path, $queue ) ) {
+                // This is a NEW job
+                // Merge job into the queue.
+                $queue[ $req_path ] = $this->ao_ccss_define_job(
+                    $req_path,
+                    $target_rule,
+                    $req_type,
+                    $hash,
+                    null,
+                    null,
+                    null,
+                    null,
+                    true
+                );
+                // Set update flag.
+                $queue_update = true;
+            } else {
+                // This is an existing job
+                // The job is still NEW, most likely this is extra CSS file for the same page that needs a hash.
+                if ( 'NEW' == $queue[ $req_path ]['jqstat'] ) {
+                    // Add hash if it's not already in the job.
+                    if ( ! in_array( $hash, $queue[ $req_path ]['hashes'] ) ) {
+                        // Push new hash to its array and update flag.
+                        $queue_update = array_push( $queue[ $req_path ]['hashes'], $hash );
+
+                        // Log job update.
+                        $this->criticalcss->log( 'Hashes UPDATED on local job id <' . $queue[ $req_path ]['ljid'] . '>, job status NEW, target rule <' . $queue[ $req_path ]['rtarget'] . '>, hash added: ' . $hash, 3 );
+
+                        // Return from here as the hash array is already updated.
+                        return true;
+                    }
+                } elseif ( 'NEW' != $queue[ $req_path ]['jqstat'] && 'JOB_QUEUED' != $queue[ $req_path ]['jqstat'] && 'JOB_ONGOING' != $queue[ $req_path ]['jqstat'] ) {
+                    // Allow requeuing jobs that are not NEW, JOB_QUEUED or JOB_ONGOING
+                    // Merge new job keeping some previous job values.
                     $queue[ $req_path ] = $this->ao_ccss_define_job(
                         $req_path,
                         $target_rule,
                         $req_type,
                         $hash,
-                        null,
-                        null,
-                        null,
-                        null,
-                        true
+                        $queue[ $req_path ]['file'],
+                        $queue[ $req_path ]['jid'],
+                        $queue[ $req_path ]['jrstat'],
+                        $queue[ $req_path ]['jvstat'],
+                        false
                     );
                     // Set update flag.
                     $queue_update = true;
-                } else {
-                    // This is an existing job
-                    // The job is still NEW, most likely this is extra CSS file for the same page that needs a hash.
-                    if ( 'NEW' == $queue[ $req_path ]['jqstat'] ) {
-                        // Add hash if it's not already in the job.
-                        if ( ! in_array( $hash, $queue[ $req_path ]['hashes'] ) ) {
-                            // Push new hash to its array and update flag.
-                            $queue_update = array_push( $queue[ $req_path ]['hashes'], $hash );
-
-                            // Log job update.
-                            $this->criticalcss->log( 'Hashes UPDATED on local job id <' . $queue[ $req_path ]['ljid'] . '>, job status NEW, target rule <' . $queue[ $req_path ]['rtarget'] . '>, hash added: ' . $hash, 3 );
-
-                            // Return from here as the hash array is already updated.
-                            return true;
-                        }
-                    } elseif ( 'NEW' != $queue[ $req_path ]['jqstat'] && 'JOB_QUEUED' != $queue[ $req_path ]['jqstat'] && 'JOB_ONGOING' != $queue[ $req_path ]['jqstat'] ) {
-                        // Allow requeuing jobs that are not NEW, JOB_QUEUED or JOB_ONGOING
-                        // Merge new job keeping some previous job values.
-                        $queue[ $req_path ] = $this->ao_ccss_define_job(
-                            $req_path,
-                            $target_rule,
-                            $req_type,
-                            $hash,
-                            $queue[ $req_path ]['file'],
-                            $queue[ $req_path ]['jid'],
-                            $queue[ $req_path ]['jrstat'],
-                            $queue[ $req_path ]['jvstat'],
-                            false
-                        );
-                        // Set update flag.
-                        $queue_update = true;
-                    }
                 }
+            }
 
-                if ( $queue_update ) {
-                    // Persist the job to the queue and return.
-                    $queue_raw = json_encode( $queue );
-                    update_option( 'autoptimize_ccss_queue', $queue_raw, false );
-                    return true;
-                } else {
-                    // Or just return false if no job was added.
-                    $this->criticalcss->log( 'A job for path <' . $req_path . '> already exist with NEW or PENDING status, skipping job creation', 3 );
-                    return false;
-                }
+            if ( $queue_update ) {
+                // Persist the job to the queue and return.
+                $queue_raw = json_encode( $queue );
+                update_option( 'autoptimize_ccss_queue', $queue_raw, false );
+                return true;
+            } else {
+                // Or just return false if no job was added.
+                $this->criticalcss->log( 'A job for path <' . $req_path . '> already exist with NEW or PENDING status, skipping job creation', 3 );
+                return false;
             }
         }
     }

--- a/classes/autoptimizeCriticalCSSEnqueue.php
+++ b/classes/autoptimizeCriticalCSSEnqueue.php
@@ -23,7 +23,7 @@ class autoptimizeCriticalCSSEnqueue {
         if ( 'nokey' == $key['status'] || 'invalid' == $key['status'] ) {
             $enqueue = false;
             $this->criticalcss->log( "Job queuing is not available: no valid API key found.", 3 );
-        } elseif ( ! empty( $hash ) && ( is_user_logged_in() || is_feed() || is_404() || ( defined( 'DOING_AJAX' ) && DOING_AJAX ) || $self->ao_ccss_ua() || false === apply_filters( 'autoptimize_filter_ccss_enqueue_should_enqueue', true ) ) ) {
+        } elseif ( ! empty( $hash ) && ( is_user_logged_in() || is_feed() || is_404() || ( defined( 'DOING_AJAX' ) && DOING_AJAX ) || $this->ao_ccss_ua() || false === apply_filters( 'autoptimize_filter_ccss_enqueue_should_enqueue', true ) ) ) {
             $enqueue = false;
             $this->criticalcss->log( "Job queuing is not available for WordPress's logged in users, feeds, error pages, ajax calls or calls from criticalcss.com itself.", 3 );
         } elseif ( empty( $hash ) && empty( $path ) || ( ( 'is_single' !== $type ) && ( 'is_page' !== $type ) ) ) {
@@ -42,7 +42,7 @@ class autoptimizeCriticalCSSEnqueue {
             // Get request path and page type, and initialize the queue update flag.
             if ( ! empty( $hash ) ) {
                 $req_orig = $_SERVER['REQUEST_URI'];
-                $req_type = $self->ao_ccss_get_type();
+                $req_type = $this->ao_ccss_get_type();
             } elseif ( ! empty( $path ) ) {
                 $req_orig = $path;
                 if ( $path === '/' ) {
@@ -146,7 +146,7 @@ class autoptimizeCriticalCSSEnqueue {
                 if ( ! array_key_exists( $req_path, $queue ) ) {
                     // This is a NEW job
                     // Merge job into the queue.
-                    $queue[ $req_path ] = $self->ao_ccss_define_job(
+                    $queue[ $req_path ] = $this->ao_ccss_define_job(
                         $req_path,
                         $target_rule,
                         $req_type,
@@ -177,7 +177,7 @@ class autoptimizeCriticalCSSEnqueue {
                     } elseif ( 'NEW' != $queue[ $req_path ]['jqstat'] && 'JOB_QUEUED' != $queue[ $req_path ]['jqstat'] && 'JOB_ONGOING' != $queue[ $req_path ]['jqstat'] ) {
                         // Allow requeuing jobs that are not NEW, JOB_QUEUED or JOB_ONGOING
                         // Merge new job keeping some previous job values.
-                        $queue[ $req_path ] = $self->ao_ccss_define_job(
+                        $queue[ $req_path ] = $this->ao_ccss_define_job(
                             $req_path,
                             $target_rule,
                             $req_type,

--- a/classes/autoptimizeCriticalCSSSettings.php
+++ b/classes/autoptimizeCriticalCSSSettings.php
@@ -15,8 +15,8 @@ class autoptimizeCriticalCSSSettings {
      */
     private $settings_screen_do_remote_http = true;
 
-    public function __construct()
-    {
+    public function __construct() {
+        $this->criticalcss = autoptimize()->criticalcss();
         $this->settings_screen_do_remote_http = apply_filters( 'autoptimize_settingsscreen_remotehttp', $this->settings_screen_do_remote_http );
         $this->run();
     }
@@ -100,12 +100,21 @@ class autoptimizeCriticalCSSSettings {
         require_once( 'critcss-inc/admin_settings_adv.php' );
         require_once( 'critcss-inc/admin_settings_explain.php' );
 
-        // fetch all options at once and populate them individually explicitely as globals.
-        $all_options = autoptimizeCriticalCSSBase::fetch_options();
-        foreach ( $all_options as $_option => $_value ) {
-            global ${$_option};
-            ${$_option} = $_value;
-        }
+        $ao_ccss_key = $this->criticalcss->get_option( 'key' );
+        $ao_ccss_keyst = $this->criticalcss->get_option( 'keyst' );
+        $ao_css_defer = $this->criticalcss->get_option( 'css_defer' );
+        $ao_ccss_deferjquery = $this->criticalcss->get_option( 'deferjquery' );
+        $ao_ccss_queue = $this->criticalcss->get_option( 'queue' );
+        $ao_ccss_servicestatus = $this->criticalcss->get_option( 'servicestatus' );
+        $ao_ccss_rules_raw = $this->criticalcss->get_option( 'rules_raw' );
+        $ao_ccss_queue_raw = $this->criticalcss->get_option( 'queue_raw' );
+        $ao_ccss_finclude = $this->criticalcss->get_option( 'finclude' );
+        $ao_ccss_rtimelimit = $this->criticalcss->get_option( 'rtimelimit' );
+        $ao_ccss_debug = $this->criticalcss->get_option( 'debug' );
+        $ao_ccss_noptimize = $this->criticalcss->get_option( 'noptimize' );
+        $ao_css_defer_inline = $this->criticalcss->get_option( 'css_defer_inline' );
+        $ao_ccss_loggedin = $this->criticalcss->get_option( 'loggedin' );
+        $ao_ccss_forcepath = $this->criticalcss->get_option( 'forcepath' );
         ?>
         <script>document.title = "Autoptimize: <?php _e( 'Critical CSS', 'autoptimize' ); ?> " + document.title;</script>
         <div class="wrap">
@@ -118,7 +127,7 @@ class autoptimizeCriticalCSSSettings {
                 // Print AO settings tabs.
                 echo autoptimizeConfig::ao_admin_tabs();
 
-                $mkdirresult = autoptimizeCriticalCSSBase::create_ao_ccss_dir();
+                $mkdirresult = $this->criticalcss->create_ao_ccss_dir();
 
                 // Warn if we could not create those files.
                 if ( ( true !== $mkdirresult ) ) {
@@ -271,7 +280,7 @@ class autoptimizeCriticalCSSSettings {
                     settings_fields( 'ao_ccss_options_group' );
 
                     // Get API key status.
-                    $key = autoptimizeCriticalCSSCore::ao_ccss_key_status( true );
+                    $key = $this->criticalcss->key_status( true );
 
                     if ( $this->is_multisite_network_admin() ) {
                         ?>
@@ -299,7 +308,7 @@ class autoptimizeCriticalCSSSettings {
                             ao_ccss_render_explain();
 
                             // Get viewport size.
-                            $viewport = autoptimizeCriticalCSSCore::ao_ccss_viewport();
+                            $viewport = $this->criticalcss->viewport();
 
                             // Add hidden fields.
                             echo "<input class='hidden' name='autoptimize_ccss_rules' value='" . $ao_ccss_rules_raw . "'>";
@@ -365,11 +374,11 @@ class autoptimizeCriticalCSSSettings {
         }
     }
 
-    public static function ao_ccss_has_autorules() {
+    public function ao_ccss_has_autorules() {
         static $_has_auto_rules = null;
 
         if ( null === $_has_auto_rules ) {
-            global $ao_ccss_rules;
+            $ao_ccss_rules = $this->criticalcss->get_option( 'rules' );
             $_has_auto_rules = false;
             if ( ! empty( $ao_ccss_rules ) ) {
                 foreach ( array( 'types', 'paths' ) as $_typat ) {
@@ -390,7 +399,7 @@ class autoptimizeCriticalCSSSettings {
         return $_has_auto_rules;
     }
 
-    public static function is_multisite_network_admin() {
+    public function is_multisite_network_admin() {
         static $_multisite_network_admin = null;
 
         if ( null === $_multisite_network_admin ) {

--- a/classes/autoptimizeCriticalCSSSettingsAjax.php
+++ b/classes/autoptimizeCriticalCSSSettingsAjax.php
@@ -8,14 +8,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class autoptimizeCriticalCSSSettingsAjax {
-    public function __construct()
-    {
-        // fetch all options at once and populate them individually explicitely as globals.
-        $all_options = autoptimizeCriticalCSSBase::fetch_options();
-        foreach ( $all_options as $_option => $_value ) {
-            global ${$_option};
-            ${$_option} = $_value;
-        }
+    public function __construct() {
+        $this->criticalcss = autoptimize()->criticalcss();
         $this->run();
     }
 
@@ -88,7 +82,7 @@ class autoptimizeCriticalCSSSettingsAjax {
             $critcsscontents = stripslashes( $_POST['critcsscontents'] );
 
             // If there is content and it's valid, write the file.
-            if ( $critcsscontents && autoptimizeCriticalCSSCore::ao_ccss_check_contents( $critcsscontents ) ) {
+            if ( $critcsscontents && $this->criticalcss->check_contents( $critcsscontents ) ) {
                 // Set file path and status.
                 $critcssfile = AO_CCSS_DIR . strip_tags( $_POST['critcssfile'] );
                 $status      = file_put_contents( $critcssfile, $critcsscontents, LOCK_EX );
@@ -216,7 +210,7 @@ class autoptimizeCriticalCSSSettingsAjax {
 
         // Init array, get options and prepare the raw object.
         $settings                        = array();
-        
+
         // CCSS settings.
         $settings['ccss']['rules']       = get_option( 'autoptimize_ccss_rules' );
         $settings['ccss']['additional']  = get_option( 'autoptimize_ccss_additional' );
@@ -232,7 +226,7 @@ class autoptimizeCriticalCSSSettingsAjax {
         $settings['ccss']['loggedin']    = get_option( 'autoptimize_ccss_loggedin' );
         $settings['ccss']['rlimit']      = get_option( 'autoptimize_ccss_rlimit' );
         $settings['ccss']['unloadccss']  = get_option( 'autoptimize_ccss_unloadccss' );
-        
+
         // JS settings.
         $settings['js']['root']                = get_option( 'autoptimize_js' );
         $settings['js']['aggregate']           = get_option( 'autoptimize_js_aggregate' );
@@ -356,7 +350,7 @@ class autoptimizeCriticalCSSSettingsAjax {
             } else {
                 $error = 'could not extract';
             }
-            
+
             // and remove temp. dir with all contents (the import-zipfile).
             $this->rrmdir( $_import_tmp_dir );
 
@@ -408,7 +402,7 @@ class autoptimizeCriticalCSSSettingsAjax {
                         } else {
                             update_option( $other_setting, $settings['other'][$other_setting] );
                         }
-                    }                    
+                    }
 
                     // AO Pro.
                     if ( defined( 'AO_PRO_VERSION' ) && array_key_exists( 'pro', $settings ) ) {
@@ -439,7 +433,7 @@ class autoptimizeCriticalCSSSettingsAjax {
         // Close ajax request.
         wp_die();
     }
-    
+
     public function ao_ccss_queuerunner_callback() {
         check_ajax_referer( 'ao_ccss_queuerunner_nonce', 'ao_ccss_queuerunner_nonce' );
 
@@ -456,7 +450,7 @@ class autoptimizeCriticalCSSSettingsAjax {
             }
         } else {
             $response['code'] = '500';
-            $response['msg']  = 'Not allowed';                        
+            $response['msg']  = 'Not allowed';
         }
 
         // Dispatch respose.
@@ -529,7 +523,7 @@ class autoptimizeCriticalCSSSettingsAjax {
             return true;
         }
     }
-    
+
     public function rrmdir( $path ) {
         // recursively remove a directory as found on
         // https://andy-carter.com/blog/recursively-remove-a-directory-in-php.

--- a/classes/autoptimizeMain.php
+++ b/classes/autoptimizeMain.php
@@ -28,6 +28,13 @@ class autoptimizeMain
     protected $filepath = null;
 
     /**
+     * Critical CSS base object
+     *
+     * @var object
+     */
+    protected $_criticalcss = null;
+
+    /**
      * Constructor.
      *
      * @param string $version Version.
@@ -219,11 +226,18 @@ class autoptimizeMain
         }
     }
 
+    public function criticalcss()
+    {
+        return $this->_criticalcss;
+    }
+
     public function maybe_run_criticalcss()
     {
         // Loads criticalcss if the power-up is not active and if the filter returns true.
         if ( apply_filters( 'autoptimize_filter_criticalcss_active', true ) && ! autoptimizeUtils::is_plugin_active( 'autoptimize-criticalcss/ao_criticss_aas.php' ) ) {
-            new autoptimizeCriticalCSSBase();
+            $this->_criticalcss = new autoptimizeCriticalCSSBase();
+            $this->_criticalcss->setup();
+            $this->_criticalcss->load_requires();
         }
     }
 
@@ -240,8 +254,8 @@ class autoptimizeMain
         $_run_compat = true;
 
         /* if ( autoptimizeOptionWrapper::get_option( 'autoptimize_installed_before_compatibility', false ) ) {
-            // If AO was already running before Compatibility logic was added, don't run compat by default 
-            // because it can be assumed everything works and we want to avoid (perf) regressions that 
+            // If AO was already running before Compatibility logic was added, don't run compat by default
+            // because it can be assumed everything works and we want to avoid (perf) regressions that
             // could occur due to compatibility code.
             $_run_compat = false;
         } */
@@ -579,7 +593,7 @@ class autoptimizeMain
     {
         // clear the cache.
         autoptimizeCache::clearall();
-        
+
         // remove postmeta if active.
         if ( autoptimizeConfig::is_ao_meta_settings_active() ) {
             delete_post_meta_by_key( 'ao_post_optimize' );

--- a/classes/autoptimizeMetabox.php
+++ b/classes/autoptimizeMetabox.php
@@ -23,7 +23,7 @@ class autoptimizeMetabox
 
     public function ao_metabox_add_box()
     {
-        $screens = array( 
+        $screens = array(
             'post',
             'page',
             // add extra types e.g. product or ... ?
@@ -42,7 +42,7 @@ class autoptimizeMetabox
 
     /**
      * Prints the box content.
-     * 
+     *
      * @param WP_Post $post The object for the current post/page.
      */
     function ao_metabox_content( $post )
@@ -50,7 +50,7 @@ class autoptimizeMetabox
         wp_nonce_field( 'ao_metabox', 'ao_metabox_nonce' );
 
         $ao_opt_value = $this->check_ao_opt_sanity( get_post_meta( $post->ID, 'ao_post_optimize', true ) );
-        
+
         $_ao_meta_sub_opacity = '';
         if ( 'on' !== $ao_opt_value['ao_post_optimize'] ) {
             $_ao_meta_sub_opacity = 'opacity:.33;';
@@ -62,7 +62,7 @@ class autoptimizeMetabox
                  <?php _e( 'Optimize this page?', 'autoptimize' ); ?>
             </label>
         </p>
-        <?php 
+        <?php
         $_ao_meta_js_style = '';
         if ( 'on' !== get_option( 'autoptimize_js', false ) ) {
             $_ao_meta_js_style = 'display:none;';
@@ -74,7 +74,7 @@ class autoptimizeMetabox
                  <?php _e( 'Optimize JS?', 'autoptimize' ); ?>
             </label>
         </p>
-        <?php 
+        <?php
         $_ao_meta_css_style = '';
         if ( 'on' !== get_option( 'autoptimize_css', false ) ) {
             $_ao_meta_css_style = 'display:none;';
@@ -86,7 +86,7 @@ class autoptimizeMetabox
                  <?php _e( 'Optimize CSS?', 'autoptimize' ); ?>
             </label>
         </p>
-        <?php 
+        <?php
         $_ao_meta_ccss_style = '';
         if ( 'on' !== get_option( 'autoptimize_css_defer', false ) ) {
             $_ao_meta_ccss_style = 'display:none;';
@@ -101,7 +101,7 @@ class autoptimizeMetabox
                  <?php _e( 'Inline critical CSS?', 'autoptimize' ); ?>
             </label>
         </p>
-        <?php 
+        <?php
         $_ao_meta_lazyload_style = '';
         if ( false === autoptimizeImages::should_lazyload_wrapper() ) {
             $_ao_meta_lazyload_style = 'display:none;';
@@ -261,11 +261,9 @@ class autoptimizeMetabox
                 $type = 'is_single';
             }
 
-            $path                = wp_strip_all_tags( $_POST['path'] );
-            $criticalcss_core    = new autoptimizeCriticalCSSCore();
-            $criticalcss_base    = new autoptimizeCriticalCSSBase();
-            $criticalcss_enqueue = new autoptimizeCriticalCSSEnqueue();
-            $_result = $criticalcss_enqueue->ao_ccss_enqueue( '', $path, $type );
+            $path = wp_strip_all_tags( $_POST['path'] );
+            $criticalcss = autoptimize()->criticalcss();
+            $_result = $criticalcss->enqueue( '', $path, $type );
 
             if ( $_result ) {
                 $response['code']   = '200';

--- a/classes/critcss-inc/admin_settings_adv.php
+++ b/classes/critcss-inc/admin_settings_adv.php
@@ -7,16 +7,17 @@
  * Function to render the advanced panel.
  */
 function ao_ccss_render_adv() {
-    // Attach required globals.
-    global $ao_ccss_debug;
-    global $ao_ccss_finclude;
-    global $ao_ccss_rtimelimit;
-    global $ao_ccss_noptimize;
-    global $ao_ccss_loggedin;
-    global $ao_ccss_forcepath;
-    global $ao_ccss_deferjquery;
-    global $ao_ccss_domain;
-    global $ao_ccss_unloadccss;
+    $criticalcss = autoptimize()->criticalcss();
+
+    $ao_ccss_debug = $criticalcss->get_option( 'debug' );
+    $ao_ccss_finclude = $criticalcss->get_option( 'finclude' );
+    $ao_ccss_rtimelimit = $criticalcss->get_option( 'rtimelimit' );
+    $ao_ccss_noptimize = $criticalcss->get_option( 'noptimize' );
+    $ao_ccss_loggedin = $criticalcss->get_option( 'loggedin' );
+    $ao_ccss_forcepath = $criticalcss->get_option( 'forcepath' );
+    $ao_ccss_deferjquery = $criticalcss->get_option( 'deferjquery' );
+    $ao_ccss_domain = $criticalcss->get_option( 'domain' );
+    $ao_ccss_unloadccss = $criticalcss->get_option( 'unloadcss' );
 
     // In case domain is not set yet (done in cron.php).
     if ( empty( $ao_ccss_domain ) ) {
@@ -24,7 +25,7 @@ function ao_ccss_render_adv() {
     }
 
     // Get viewport size.
-    $viewport = autoptimizeCriticalCSSCore::ao_ccss_viewport();
+    $viewport = $criticalcss->viewport();
 ?>
     <ul id="adv-panel">
         <li class="itemDetail">

--- a/classes/critcss-inc/admin_settings_adv.php
+++ b/classes/critcss-inc/admin_settings_adv.php
@@ -17,7 +17,7 @@ function ao_ccss_render_adv() {
     $ao_ccss_forcepath = $criticalcss->get_option( 'forcepath' );
     $ao_ccss_deferjquery = $criticalcss->get_option( 'deferjquery' );
     $ao_ccss_domain = $criticalcss->get_option( 'domain' );
-    $ao_ccss_unloadccss = $criticalcss->get_option( 'unloadcss' );
+    $ao_ccss_unloadccss = $criticalcss->get_option( 'unloadccss' );
 
     // In case domain is not set yet (done in cron.php).
     if ( empty( $ao_ccss_domain ) ) {

--- a/classes/critcss-inc/admin_settings_queue.php
+++ b/classes/critcss-inc/admin_settings_queue.php
@@ -8,7 +8,8 @@
  */
 function ao_ccss_render_queue() {
     // Attach required arrays.
-    global $ao_ccss_queue;
+    $criticalcss = autoptimize()->criticalcss();
+    $ao_ccss_queue = $criticalcss->get_option( 'queue' );
 
     // Prepare the queue object.
     if ( empty( $ao_ccss_queue ) ) {
@@ -25,7 +26,7 @@ function ao_ccss_render_queue() {
                 <span class="toggle-indicator dashicons dashicons-arrow-up dashicons-arrow-down"></span>
             </button>
             <?php
-            if ( autoptimizeCriticalCSSSettings::ao_ccss_has_autorules() ) {
+            if ( $criticalcss->has_autorules() ) {
                 $_queue_visibility = 'hidden';
             } else {
                 $_queue_visibility = 'visible';

--- a/classes/critcss-inc/admin_settings_rules.php
+++ b/classes/critcss-inc/admin_settings_rules.php
@@ -8,8 +8,9 @@
  */
 function ao_ccss_render_rules() {
     // Attach required arrays.
-    global $ao_ccss_rules;
-    global $ao_ccss_types;
+    $criticalcss = autoptimize()->criticalcss();
+    $ao_ccss_rules = $criticalcss->get_option( 'rules' );
+    $ao_ccss_types = $criticalcss->get_option( 'types' );
 ?>
     <ul id="rules-panel">
         <li class="itemDetail">

--- a/classes/critcss-inc/admin_settings_rules.php
+++ b/classes/critcss-inc/admin_settings_rules.php
@@ -10,7 +10,7 @@ function ao_ccss_render_rules() {
     // Attach required arrays.
     $criticalcss = autoptimize()->criticalcss();
     $ao_ccss_rules = $criticalcss->get_option( 'rules' );
-    $ao_ccss_types = $criticalcss->get_option( 'types' );
+    $ao_ccss_types = $criticalcss->get_types();
 ?>
     <ul id="rules-panel">
         <li class="itemDetail">


### PR DESCRIPTION
* Removes the use of global variables to store Critical CSS options
* Introduces a `->criticalcss` pointer to the main base object in modules where needed
* Introduces a `autoptimize()->criticalcss()` method to return the main base object when needed outside of the CCSS modules
* Introduces `->get_option()` and `->flush_options()` as a replacement for global variables
* Adds a number of pass-through methods in the base class to access child modules methods (enqueue, log, viewport, etc.)