### PR TITLE
Compatibility with Real Cookie Banner

### DIFF
--- a/classes/autoptimizeStyles.php
+++ b/classes/autoptimizeStyles.php
@@ -306,7 +306,7 @@ class autoptimizeStyles extends autoptimizeBase
 
                     $media = apply_filters( 'autoptimize_filter_css_tagmedia', $media, $tag );
 
-                    if ( preg_match( '#<link.*href=("|\')(.*)("|\')#Usmi', $tag, $source ) ) {
+                    if ( preg_match( '#<link.*href(?:-_)?=("|\')(.*)("|\')#Usmi', $tag, $source ) ) {
                         // <link>.
                         $url  = current( explode( '?', $source[2], 2 ) );
                         $path = $this->getpath( $url );


### PR DESCRIPTION
Hello!

Here is Matthew, developer behind the [Real Cookie Banner](https://wordpress.org/plugins/real-cookie-banner/) plugin. 👋

We have a feature which allows blocking content until the user gives consent (GDPR). For this, `link rel="stylesheet"` tags gets modified in the following way:

```html
   <link id="termin-btn-menu" href="https://calendly.com/assets/external/widget.css" rel="stylesheet">
-> <link id="termin-btn-menu" consent-original-href-_="https://calendly.com/assets/external/widget.css" rel="stylesheet">
                              ^^^^^^^^^^^^^^^^^    ^^
```

As you can see, we need to wrap the `href` to `consent-original-href-_`.

Now, when users activate the option **Also aggregate inline CSS?**, Autoptimize removes the node completely as the `link` is considered as inline style.

To resolve this, Autoptimize needs to change the regular expression which determines between external resource and inline style. Here is a modified regular expression respecting also the markup of Real Cookie Banner: https://regex101.com/r/tG0Bqa/1