### PR TITLE
Fix argument type of parent slug in add_submenu_page()

### DIFF
--- a/classes/autoptimizeBase.php
+++ b/classes/autoptimizeBase.php
@@ -150,7 +150,7 @@ abstract class autoptimizeBase
             // As we replaced the content-domain with the site-domain, we should match against that.
             $tmp_ao_root = preg_replace( '/https?:/', '', AUTOPTIMIZE_WP_SITE_URL );
         }
-        
+
         if ( is_multisite() && ! is_main_site() && ! empty( $this->cdn_url ) && apply_filters( 'autoptimize_filter_base_getpage_multisite_cdn_juggling', true ) ) {
             // multisite child sites with CDN need the network_site_url as tmp_ao_root but only if directory-based multisite.
             $_network_site_url = network_site_url();
@@ -171,8 +171,8 @@ abstract class autoptimizeBase
 
         // Prepend with WP_ROOT_DIR to have full path to file.
         $path = str_replace( '//', '/', trailingslashit( WP_ROOT_DIR ) . $path );
-        
-        // Allow path to be altered, e.g. in the case of bedrock-like setups where 
+
+        // Allow path to be altered, e.g. in the case of bedrock-like setups where
         // core, theme & plugins might be in different locations on the filesystem.
         $path = apply_filters( 'autoptimize_filter_base_getpath_path', $path, $url );
 

--- a/classes/autoptimizeCache.php
+++ b/classes/autoptimizeCache.php
@@ -391,7 +391,7 @@ class autoptimizeCache
                 return false;
             }
         }
-        
+
         if ( ! self::cacheavail() ) {
             return false;
         }
@@ -823,7 +823,7 @@ class autoptimizeCache
             $_kinsta_clear_cache_url = 'https://localhost/kinsta-clear-cache-all';
             $_kinsta_response        = wp_remote_get(
                 $_kinsta_clear_cache_url,
-                array( 
+                array(
                     'sslverify' => false,
                     'timeout' => 5,
                     )

--- a/classes/autoptimizeCompatibility.php
+++ b/classes/autoptimizeCompatibility.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Multiple compatibility snippets to ensure important/ stubborn plugins work out of the box.
- * 
+ *
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -24,7 +24,7 @@ class autoptimizeCompatibility
 
     /**
      * Runs multiple compatibility snippets to ensure important plugins work out of the box.
-     * 
+     *
      */
     public function run()
     {
@@ -32,7 +32,7 @@ class autoptimizeCompatibility
         if ( defined( 'ELEMENTOR_VERSION' ) && is_user_logged_in() && current_user_can( 'edit_posts' ) && apply_filters( 'autoptimize_filter_compatibility_editelementor_active', true ) ) {
             add_filter( 'autoptimize_filter_js_noptimize', '__return_true' );
         }
-        
+
         // Revslider; jQuery should not be deferred + exclude all revslider JS.
         if ( defined( 'RS_REVISION' ) && $this->conf->get( 'autoptimize_js' ) && true == $this->inline_js_config_checker() && apply_filters( 'autoptimize_filter_compatibility_revslider_active', true ) ) {
             add_filter( 'autoptimize_filter_js_exclude', function( $js_excl = '', $html = '' ) {
@@ -41,24 +41,24 @@ class autoptimizeCompatibility
                     if ( is_array( $js_excl ) ) {
                         $js_excl = implode( ',', $js_excl );
                     }
-                    
+
                     $js_excl .= ',' . $revslider_excl;
                 }
                 return $js_excl;
             }, 11, 2 );
         }
-        
+
         // Revslider; remove revslider JS if no slides in HTML for non-logged in users.
         if ( defined( 'RS_REVISION' ) && $this->conf->get( 'autoptimize_js' ) && false === is_user_logged_in() && apply_filters( 'autoptimize_filter_compatibility_revslider_remover_active', true ) ) {
             add_filter( 'autoptimize_filter_js_removables', function( $to_remove = '', $html = '' ) {
                 if ( ! empty( $html ) && false === strpos( $html, '<rs-slides>') ) {
                     $to_remove .= 'plugins/revslider, setREVStartSize, window.RSIW, window.RS_MODULES';
                 }
-                
+
                 return $to_remove;
-            }, 11, 2 ); 
+            }, 11, 2 );
         }
-        
+
         // Exclude jQuery if inline JS is found that requires jQuery.
         if ( $this->inline_js_config_checker() && false === strpos( $this->conf->get( 'autoptimize_js_exclude' ), 'jquery.min.js' ) && apply_filters( 'autoptimize_filter_compatibility_inline_jquery', true ) ) {
             add_filter( 'autoptimize_filter_js_exclude', function( $js_excl = '', $html = '' ) {
@@ -66,7 +66,7 @@ class autoptimizeCompatibility
                     if ( is_array( $js_excl ) ) {
                         $js_excl = implode( ',', $js_excl );
                     }
-                    
+
                     if ( false === strpos( $js_excl, 'jquery.min.js' ) ) {
                         $js_excl .= ', jquery.min.js';
                     }
@@ -79,7 +79,7 @@ class autoptimizeCompatibility
                 return $js_excl;
             }, 12, 2 );
         }
-        
+
         // Make JS-based Gutenberg blocks work OOTB.
         if ( $this->inline_js_config_checker() && apply_filters( 'autoptimize_filter_compatibility_gutenberg_js', true ) ) {
             add_filter( 'autoptimize_filter_js_exclude', function( $js_excl = '', $html = '' ) {
@@ -87,7 +87,7 @@ class autoptimizeCompatibility
                     if ( is_array( $js_excl ) ) {
                         $js_excl = implode( ',', $js_excl );
                     }
-                    
+
                     if ( false === strpos( $js_excl, 'jquery.min.js' ) ) {
                         $js_excl .= ', jquery.min.js';
                     }
@@ -100,10 +100,10 @@ class autoptimizeCompatibility
             }, 13, 2 );
         }
     }
-    
+
     public function inline_js_config_checker() {
         static $inline_js_flagged = null;
-        
+
         if ( null === $inline_js_flagged ) {
             if ( ( $this->conf->get( 'autoptimize_js_aggregate' ) || apply_filters( 'autoptimize_filter_js_dontaggregate', false ) ) && apply_filters( 'autoptimize_js_include_inline', $this->conf->get( 'autoptimize_js_include_inline' ) ) ) {
                 // if all files and also inline JS are aggregated we don't have to worry about inline JS.
@@ -116,7 +116,7 @@ class autoptimizeCompatibility
             // in all other cases we need to pay attention to inline JS requiring src'ed JS to be available.
             $inline_js_flagged = true;
         }
-        
+
         return $inline_js_flagged;
     }
 }

--- a/classes/autoptimizeConfig.php
+++ b/classes/autoptimizeConfig.php
@@ -62,7 +62,7 @@ class autoptimizeConfig
             }
 
             $this->settings_screen_do_remote_http = apply_filters( 'autoptimize_settingsscreen_remotehttp', $this->settings_screen_do_remote_http );
-            
+
             if ( $this->is_ao_meta_settings_active() ) {
                 $metaBox = new autoptimizeMetabox();
             }
@@ -227,7 +227,7 @@ if ( is_network_admin() && autoptimizeOptionWrapper::is_ao_active_for_network() 
     </li>
 <?php } else { ?>
     <input type="hidden" id="autoptimize_enable_site_config" name="autoptimize_enable_site_config" value="on" />
-<?php } ?>    
+<?php } ?>
 
 <li class="itemDetail">
 <h2 class="itemTitle"><?php _e( 'JavaScript Options', 'autoptimize' ); ?></h2>
@@ -359,7 +359,7 @@ echo __( 'A comma-separated list of CSS you want to exclude from being optimized
 <?php if ( false === autoptimizeUtils::is_plugin_active( 'unusedcss/unusedcss.php' ) ) { ?>
 <tr valign="top">
 <th scope="row"><?php _e( 'Remove Unused CSS?', 'autoptimize' ); ?></th>
-<?php 
+<?php
 $_rapidload_link = 'https://misc.optimizingmatters.com/partners/?from=csssettings&partner=rapidload';
 ?>
 <td><?php echo sprintf( __( 'If Google Pagespeed Insights detects unused CSS, consider using %s to <strong>reduce your site\'s CSS size to up to 90&#37;</strong>, resulting in a slimmer, faster site!', 'autoptimize' ), '<a href="' . $_rapidload_link . '" target="_blank">the premium Rapidload service</a>' ); ?></td>
@@ -402,7 +402,7 @@ if ( true === autoptimizeImages::imgopt_active() && true === apply_filters( 'aut
 } else {
     $cdn_editable    = '';
     $cdn_placeholder = 'placeholder="' . __( 'example: //cdn.yoursite.com/', 'autoptimize' ) . ' "';
-    $cdn_description = __( 'Enter your CDN root URL to enable CDN for Autoptimized files. The URL can be http, https or protocol-relative. This is not needed for Cloudflare.', 'autoptimize' );    
+    $cdn_description = __( 'Enter your CDN root URL to enable CDN for Autoptimized files. The URL can be http, https or protocol-relative. This is not needed for Cloudflare.', 'autoptimize' );
 }
 ?>
 <td><label><input id="cdn_url" type="text" name="autoptimize_cdn_url" pattern="^(https?:)?\/\/([\da-z\.-]+)\.([\da-z\.]{2,6})([\/\w \.-]*)*(:\d{2,5})?\/?$" style="width:100%" <?php echo $cdn_placeholder . $cdn_editable; ?> value="<?php echo esc_url( autoptimizeOptionWrapper::get_option( 'autoptimize_cdn_url', '' ), array( 'http', 'https' ) ); ?>" /><br />
@@ -496,7 +496,7 @@ if ( true === autoptimizeImages::imgopt_active() && true === apply_filters( 'aut
     <th scope="row"><?php _e( 'Disable extra compatibilty logic?', 'autoptimize' ); ?></th>
     <td><label class="cb_label"><input type="checkbox" name="autoptimize_installed_before_compatibility" checked="checked" />
     <?php _e( 'In Autoptimize 3.0 extra compatibiity logic was added (e.g. for Gutenberg blocks, Revolution Slider, jQuery-heavy plugins, ...), but if you had Autoptimize installed already before the update to 3.0, this compatibility code was disabled. <strong>Untick this option to permanently enable the compatibility logic</strong>.', 'autoptimize' ); ?></label></td>
-    </tr>        
+    </tr>
     <?php } ?>
 </table>
 </li>
@@ -588,7 +588,7 @@ if ( true === autoptimizeImages::imgopt_active() && true === apply_filters( 'aut
                 check_exclusions( "js", "off" );
             }
         });
-        
+
         jQuery( "#autoptimize_js_defer_not_aggregate" ).change(function() {
             if (this.checked && jQuery("#autoptimize_js").prop('checked')) {
                 jQuery( "#autoptimize_js_aggregate" ).prop( 'checked', false ); // uncheck "aggregate JS"
@@ -690,7 +690,7 @@ if ( true === autoptimizeImages::imgopt_active() && true === apply_filters( 'aut
             jQuery(".js_sub:visible").fadeTo('fast',.33);
         }
     }
-    
+
     function check_exclusions( what, state ) {
         exclusion_node = 'input[name="autoptimize_' + what + '_exclude"]';
         current_exclusion = jQuery( exclusion_node ).val();
@@ -700,9 +700,9 @@ if ( true === autoptimizeImages::imgopt_active() && true === apply_filters( 'aut
         } else if ( what == "css")  {
             default_exclusion = ", admin-bar.min.css, dashicons.min.css, wp-content/cache/, wp-content/uploads/";
         }
-        
+
         default_in_current = current_exclusion.indexOf(default_exclusion);
-        
+
         if ( state == "on" && default_in_current == -1 ) {
             jQuery( exclusion_node ).val( current_exclusion + default_exclusion );
         } else if ( state = "off" && current_exclusion == default_exclusion ) {
@@ -1057,7 +1057,7 @@ if ( true === autoptimizeImages::imgopt_active() && true === apply_filters( 'aut
             return true;
         } else if ( array_key_exists( 'ao_post_optimize', $_meta_value ) && 'on' !== $_meta_value['ao_post_optimize'] ) {
             // ao entirely off for this page.
-            return false; 
+            return false;
         } else if ( array_key_exists( $optim, $_meta_value ) && empty( $_meta_value[$optim] ) ) {
             // sub-optimization off for this page.
             return false;

--- a/classes/autoptimizeCriticalCSSBase.php
+++ b/classes/autoptimizeCriticalCSSBase.php
@@ -86,7 +86,7 @@ class autoptimizeCriticalCSSBase {
         }
 
         $this->filepath = __FILE__;
-        
+
         // Add keychecker action for scheduled use.
         add_action( 'ao_ccss_keychecker', array( $this, 'ao_ccss_check_key' ) );
     }
@@ -109,7 +109,7 @@ class autoptimizeCriticalCSSBase {
                 // and schedule maintenance job.
                 wp_schedule_event( time(), 'twicedaily', 'ao_ccss_maintenance' );
             }
-            
+
             if ( wp_next_scheduled( 'ao_ccss_keychecker' ) ) {
                 // api is active now, no need to check key as it is checked by using the API.
                 wp_clear_scheduled_hook( 'ao_ccss_keychecker' );
@@ -419,7 +419,7 @@ class autoptimizeCriticalCSSBase {
      * Scheduled action to check an inactive key. Not part of autoptimizeCriticalCSSCron.php
      * to allow us to only load the main cron logic if we have an active key to begin with.
      *
-     */    
+     */
     public function ao_ccss_check_key() {
         $ao_ccss_key = $this->get_option( 'key' );
         $_result = $this->_core->ao_ccss_key_validation( $ao_ccss_key );

--- a/classes/autoptimizeCriticalCSSSettings.php
+++ b/classes/autoptimizeCriticalCSSSettings.php
@@ -70,7 +70,7 @@ class autoptimizeCriticalCSSSettings {
         register_setting( 'ao_ccss_options_group', 'autoptimize_ccss_unloadccss' );
 
         // And add submenu-page.
-        add_submenu_page( null, 'Critical CSS', 'Critical CSS', 'manage_options', 'ao_critcss', array( $this, 'ao_criticalcsssettings_page' ) );
+        add_submenu_page( '', 'Critical CSS', 'Critical CSS', 'manage_options', 'ao_critcss', array( $this, 'ao_criticalcsssettings_page' ) );
     }
 
     public function admin_assets( $hook ) {

--- a/classes/autoptimizeExitSurvey.php
+++ b/classes/autoptimizeExitSurvey.php
@@ -30,7 +30,7 @@ class autoptimizeExitSurvey
 
     function render_survey_model() {
         global $wp_version;
-        
+
         $data = array(
             "home" => home_url(),
             "dest" => 'aHR0cHM6Ly9taXNjLm9wdGltaXppbmdtYXR0ZXJzLmNvbS9hb19leGl0X3N1cnZleS9pbmRleC5waHA='

--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -189,7 +189,7 @@ class autoptimizeExtra
         if ( ! empty( $options['autoptimize_extra_text_field_7'] ) || has_filter( 'autoptimize_filter_extra_tobepreloaded' ) || ! empty( autoptimizeConfig::get_post_meta_ao_settings( 'ao_post_preload' ) ) ) {
             add_filter( 'autoptimize_html_after_minify', array( $this, 'filter_preload' ), 10, 2 );
         }
-        
+
         // Remove global styles.
         if ( ! empty( $options['autoptimize_extra_checkbox_field_8'] ) ) {
             $this->disable_global_styles();
@@ -409,7 +409,7 @@ class autoptimizeExtra
         if ( array_key_exists( 'autoptimize_extra_text_field_7', $options ) ) {
             $preloads = array_filter( array_map( 'trim', explode( ',', wp_strip_all_tags( $options['autoptimize_extra_text_field_7'] ) ) ) );
         }
-        
+
         if ( false === autoptimizeImages::imgopt_active() && false === autoptimizeImages::should_lazyload_wrapper() ) {
             // only do this here if imgopt/ lazyload are not active?
             $metabox_preloads = array_filter( array_map( 'trim', explode( ',', wp_strip_all_tags( autoptimizeConfig::get_post_meta_ao_settings( 'ao_post_preload' ) ) ) ) );
@@ -460,7 +460,7 @@ class autoptimizeExtra
 
         return $this->inject_preloads( $preload_output, $in );
     }
-    
+
     public static function inject_preloads( $preloads, $html ) {
         // add string to head (before first link node by default).
         $preload_inject = apply_filters( 'autoptimize_filter_extra_preload_inject', '<link' );
@@ -468,7 +468,7 @@ class autoptimizeExtra
 
         return autoptimizeUtils::substr_replace( $html, $preloads . $preload_inject, $position, strlen( $preload_inject ) );
     }
-    
+
     public function disable_global_styles()
     {
         remove_action( 'wp_enqueue_scripts', 'wp_enqueue_global_styles' );
@@ -488,7 +488,7 @@ class autoptimizeExtra
         // no acces if multisite and not network admin and no site config allowed.
         if ( autoptimizeConfig::should_show_menu_tabs() ) {
             add_submenu_page(
-                null,
+                '',
                 'autoptimize_extra',
                 'autoptimize_extra',
                 'manage_options',

--- a/classes/autoptimizeHTML.php
+++ b/classes/autoptimizeHTML.php
@@ -48,7 +48,7 @@ class autoptimizeHTML extends autoptimizeBase
 
         // Filter to force xhtml.
         $this->forcexhtml = (bool) apply_filters( 'autoptimize_filter_html_forcexhtml', false );
-        
+
         // minify inline JS/ CSS.
         $this->minify_inline = (bool) apply_filters( 'autoptimize_html_minify_inline_js_css', $options['minify_inline'] );
 

--- a/classes/autoptimizeImages.php
+++ b/classes/autoptimizeImages.php
@@ -653,7 +653,7 @@ class autoptimizeImages
                     // then call add_lazyload-function with lpiq placeholder if set.
                     $tag = $this->add_lazyload( $tag, $placeholder );
                 }
-                
+
                 // add decoding="async" behind filter, not sure if I'll make it default true yet.
                 if ( true === apply_filters( 'autoptimize_filter_imgopt_add_decoding', true ) && false === strpos( $tag, ' decoding=' ) ) {
                     $tag = str_replace( '<img ', '<img decoding="async" ', $tag );
@@ -665,7 +665,7 @@ class autoptimizeImages
                 if ( $tag !== $orig_tag ) {
                     $to_replace[ $orig_tag ] = $tag;
                 }
-                
+
                 // and check if image needs to be prelaoded.
                 if ( ! empty( $metabox_preloads ) && is_array( $metabox_preloads ) && str_replace( $metabox_preloads, '', $tag ) !== $tag ) {
                     $to_preload .= $this->create_img_preload_tag( $tag );
@@ -831,7 +831,7 @@ class autoptimizeImages
                 if ( $this->should_lazyload( $out ) ) {
                     $to_replace[ $tag ] = $this->add_lazyload( $tag );
                 }
-                
+
                 // and check if image needs to be prelaoded.
                 if ( ! empty( $metabox_preloads ) && is_array( $metabox_preloads ) && str_replace( $metabox_preloads, '', $tag ) !== $tag ) {
                     $to_preload .= $this->create_img_preload_tag( $tag );
@@ -955,7 +955,7 @@ class autoptimizeImages
         echo apply_filters( 'autoptimize_filter_imgopt_lazyload_jsconfig', '<script' . $type_js . $noptimize_flag . '>window.lazySizesConfig=window.lazySizesConfig||{};window.lazySizesConfig.loadMode=1;</script>' );
         echo apply_filters( 'autoptimize_filter_imgopt_lazyload_js', '<script async' . $type_js . $noptimize_flag . ' src=\'' . $lazysizes_js . '\'></script>' );
     }
-    
+
     public static function create_img_preload_tag( $tag ) {
         if ( false === apply_filters( 'autoptimize_filter_imgopt_dopreloads', true ) ) {
             return '';
@@ -968,7 +968,7 @@ class autoptimizeImages
         $_from = array( '<img ', ' src=', ' sizes=', ' srcset=' );
         $_to   = array( '<link rel="preload" as="image" ', ' href=', ' imagesizes=', ' imagesrcset=' );
         $tag   = str_replace( $_from, $_to, $tag );
-        
+
         // and remove title, alt, class and id.
         $tag = preg_replace( '/ ((?:title|alt|class|id|loading)=".*")/Um', '', $tag );
         if ( $tag !== str_replace( array(' title=', ' class=', ' alt=', ' id=' ), '', $tag ) ) {
@@ -1113,7 +1113,7 @@ class autoptimizeImages
         }
         return $matches[0];
     }
-    
+
     public function fix_silly_bgimg_quotes( $tag_in ) {
         // some themes/ pagebuilders wrap backgroundimages in HTML-encoded quotes (or linebreaks) which breaks imgopt/ lazyloading, this removes them.
         return trim( str_replace( array( "\r\n", '&quot;', '&#034;', '&apos;', '&#039;' ), '', $tag_in ) );
@@ -1138,7 +1138,7 @@ class autoptimizeImages
         // no acces if multisite and not network admin and no site config allowed.
         if ( autoptimizeConfig::should_show_menu_tabs() ) {
             add_submenu_page(
-                null,
+                '',
                 'autoptimize_imgopt',
                 'autoptimize_imgopt',
                 'manage_options',

--- a/classes/autoptimizeMetabox.php
+++ b/classes/autoptimizeMetabox.php
@@ -28,7 +28,7 @@ class autoptimizeMetabox
             'page',
             // add extra types e.g. product or ... ?
         );
-        
+
         $screens = apply_filters( 'autoptimize_filter_metabox_screens', $screens );
 
         foreach ( $screens as $screen ) {

--- a/classes/autoptimizePartners.php
+++ b/classes/autoptimizePartners.php
@@ -44,7 +44,7 @@ class autoptimizePartners
     public function add_admin_menu()
     {
         if ( $this->enabled() ) {
-            add_submenu_page( null, 'AO partner', 'AO partner', 'manage_options', 'ao_partners', array( $this, 'ao_partners_page' ) );
+            add_submenu_page( '', 'AO partner', 'AO partner', 'manage_options', 'ao_partners', array( $this, 'ao_partners_page' ) );
         }
     }
 

--- a/classes/autoptimizeScripts.php
+++ b/classes/autoptimizeScripts.php
@@ -119,7 +119,7 @@ class autoptimizeScripts extends autoptimizeBase
      * @var bool
      */
     private $defer_not_aggregate = false;
-    
+
     /**
      * Setting; defer inline JS?
      *
@@ -220,7 +220,7 @@ class autoptimizeScripts extends autoptimizeBase
     public function read( $options )
     {
         $noptimize_js = false;
-        
+
         // If page/ post check post_meta to see if optimize is off.
         if ( false === autoptimizeConfig::get_post_meta_ao_settings( 'ao_post_js_optimize' ) ) {
             $noptimize_js = true;
@@ -228,7 +228,7 @@ class autoptimizeScripts extends autoptimizeBase
 
         // And a filter to enforce JS noptimize.
         $noptimize_js = apply_filters( 'autoptimize_filter_js_noptimize', $noptimize_js, $this->content );
-        
+
         // And finally bail if noptimize_js is true.
         if ( $noptimize_js ) {
             return false;
@@ -263,12 +263,12 @@ class autoptimizeScripts extends autoptimizeBase
         }
         // and the filter that should have been there to begin with.
         $this->aggregate = apply_filters( 'autoptimize_filter_js_aggregate', $this->aggregate );
-        
+
         // Defer when not aggregating.
         if ( false === $this->aggregate && apply_filters( 'autoptimize_filter_js_defer_not_aggregate', $options['defer_not_aggregate'] ) ) {
             $this->defer_not_aggregate = true;
         }
-        
+
         // Defer inline JS?
         if ( ( true === $this->defer_not_aggregate && apply_filters( 'autoptimize_js_filter_defer_inline', $options['defer_inline'] ) ) || apply_filters( 'autoptimize_js_filter_force_defer_inline', false ) ) {
             $this->defer_inline = true;

--- a/classes/autoptimizeStyles.php
+++ b/classes/autoptimizeStyles.php
@@ -368,7 +368,7 @@ class autoptimizeStyles extends autoptimizeBase
                         if ( '' !== $new_tag ) {
                             // Optionally defer (preload) non-aggregated CSS.
                             $new_tag = $this->optionally_defer_excluded( $new_tag, $url );
-                            
+
                             // Check if we still need to CDN (esp. for already minified resources).
                             if ( ! empty( $this->cdn_url ) || has_filter( 'autoptimize_filter_base_replace_cdn' ) ) {
                                 $new_tag = str_replace( $url, $this->url_replace_cdn( $url ), $new_tag );

--- a/classes/autoptimizeUtils.php
+++ b/classes/autoptimizeUtils.php
@@ -400,7 +400,7 @@ class autoptimizeUtils
      * Now used to show notice, might be used later on to (un)hide page caching in AO if no page cache found.
      *
      * @return bool
-     */    
+     */
     public static function find_pagecache( $disregard_transient = false ) {
         static $_found_pagecache = null;
 
@@ -441,7 +441,7 @@ class autoptimizeUtils
                         }
                     }
                 }
-                
+
                 // store in transient for 1 week if pagecache found.
                 if ( true === $_found_pagecache && true !== $disregard_transient ) {
                     set_transient( $_ao_pagecache_transient, true, WEEK_IN_SECONDS );
@@ -457,7 +457,7 @@ class autoptimizeUtils
      * Used to limit notifications to AO settings pages.
      *
      * @return bool
-     */    
+     */
     public static function is_ao_settings() {
         $_is_ao_settings = ( str_replace( array( 'autoptimize', 'autoptimize_imgopt', 'ao_critcss', 'autoptimize_extra', 'ao_partners' ), '', $_SERVER['REQUEST_URI'] ) !== $_SERVER['REQUEST_URI'] ? true : false );
         return $_is_ao_settings;

--- a/classes/autoptimizeVersionUpdatesHandler.php
+++ b/classes/autoptimizeVersionUpdatesHandler.php
@@ -263,7 +263,7 @@ class autoptimizeVersionUpdatesHandler
 
     /**
      * remove CCSS request limit option + update jquery exclusion to include WordPress 5.6 jquery.min.js.
-     */    
+     */
     private function upgrade_from_2_7() {
         delete_option( 'autoptimize_ccss_rlimit' );
         $js_exclusions = get_option( 'autoptimize_js_exclude', '' );
@@ -272,9 +272,9 @@ class autoptimizeVersionUpdatesHandler
             autoptimizeOptionWrapper::update_option( 'autoptimize_js_exclude', $js_exclusions );
         }
     }
-    
+
     /**
-     * set an option to indicate the AO installation predates the compatibility logic, this way we 
+     * set an option to indicate the AO installation predates the compatibility logic, this way we
      * can avoid adding compatibility code that is likely not needed and maybe not wanted as it
      * can introduce performance regressions.
      */

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "phpunit/phpunit": "^7.5.0",
         "wimg/php-compatibility": "*",
         "wp-coding-standards/wpcs": "*",
-	"yoast/phpunit-polyfills": "*"
+        "yoast/phpunit-polyfills": "*"
     },
     "scripts": {
         "test": [


### PR DESCRIPTION
This PR fixes the argument type of `$parent_slug` in `add_submenu_page()`. `$parent_slug` is expected to be of type string (see the [code reference](https://developer.wordpress.org/reference/functions/add_submenu_page/)). Passing `null` causes the following deprecation notices in PHP 8.1 (haven't tried with PHP 8.0):
* `strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated`
* `str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated`