### PR TITLE
fix: compatibility with Real Cookie Banner and Google Fonts removal

### DIFF
--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -266,6 +266,12 @@ class autoptimizeExtra
         if ( '2' === $options['autoptimize_extra_radio_field_4'] ) {
             // Remove Google Fonts.
             unset( $fonts_collection );
+            
+            // Real Cookie Banner compatibility: Do not show this markup as Google Font result in the scanner
+            if (isset($_GET['rcb-scan'])) {
+                return str_replace('<link', '<link consent-scanner-skip', $in, 1);
+            }
+            
             return $in;
         } elseif ( '3' === $options['autoptimize_extra_radio_field_4'] || '5' === $options['autoptimize_extra_radio_field_4'] ) {
             // Aggregate & link!


### PR DESCRIPTION
Hello!

Here is Matthew, developer behind the [Real Cookie Banner](https://wordpress.org/plugins/real-cookie-banner/) plugin. 👋

We have a feature which allows blocking content until the user gives consent (GDPR). For this, `link rel="stylesheet"` tags gets modified in the following way:

```html
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@100&display=swap" rel="stylesheet">
-> <link consent-original-href-_="https://fonts.googleapis.com/css2?family=Roboto:wght@100&display=swap" rel="stylesheet">
         ^^^^^^^^^^^^^^^^^    ^^
```

As you can see, we need to wrap the `href` to `consent-original-href-_`.

Now, when the user chooses the option "Remove Google Fonts" (_Extra > Google Fonts_) the Real Cookie Banner scanner still finds Google Fonts:

![image](https://user-images.githubusercontent.com/1008534/188385668-937f4c36-be2f-4992-a3b1-cfce047657ea.png)

Why? Autoptimize is using the filter `autoptimize_html_after_minify` instead of `autoptimize_filter_html_before_minify` to extract the Google Fonts stylesheets:

https://github.com/futtta/autoptimize/blob/536be4d19d4019b5bbd01dd0065a6b5a28cbb88c/classes/autoptimizeExtra.php#L179

Real Cookie Banner itself needs to rely on the `autoptimize_filter_html_before_minify` filter, as the scanner **must** proceed non-modified HTML code.

Two potential solutions:

- Use `autoptimize_filter_html_before_minify` instead of `autoptimize_html_after_minify` for the `filter_optimize_google_fonts` function
- Approve this commit and do not remove the markup from the HTML in scan-mode, instead mark the `<link` as skippable for the scanner.