### PR TITLE
Change filter to disable emoji dns-prefetch

### DIFF
--- a/classes/autoptimizeExtra.php
+++ b/classes/autoptimizeExtra.php
@@ -101,7 +101,7 @@ class autoptimizeExtra
         add_filter( 'tiny_mce_plugins', array( $this, 'filter_disable_emojis_tinymce' ) );
 
         // Removes emoji dns-preftech.
-        add_filter( 'wp_resource_hints', array( $this, 'filter_remove_emoji_dns_prefetch' ), 10, 2 );
+        add_filter( 'emoji_svg_url', '__return_false' );
     }
 
     public function filter_disable_emojis_tinymce( $plugins )
@@ -203,13 +203,6 @@ class autoptimizeExtra
         if ( ! empty( $options['autoptimize_extra_checkbox_field_8'] ) ) {
             $this->disable_global_styles();
         }
-    }
-
-    public function filter_remove_emoji_dns_prefetch( $urls, $relation_type )
-    {
-        $emoji_svg_url = apply_filters( 'emoji_svg_url', 'https://s.w.org/images/core/emoji/' );
-
-        return $this->filter_remove_dns_prefetch( $urls, $relation_type, $emoji_svg_url );
     }
 
     public function filter_remove_gfonts_dnsprefetch( $urls, $relation_type )


### PR DESCRIPTION
Changed filter to disable emoji dns-prefetch that doesn't require checking emoji URL. Fixes #394 

One thing to note, looks like WordPress removed this dns-prefetch. They removed `emoji_svg_url` from `wp_resource_hints` recently: https://github.com/WordPress/wordpress-develop/pull/3055 

### Tests (before/after)
WordPress 4.9.22
![image](https://user-images.githubusercontent.com/1692600/212170173-96e52397-5829-4be0-99e9-b1282bee2693.png)


ClassicPress 1.5.0
![image](https://user-images.githubusercontent.com/1692600/212169538-1812a462-f683-412e-a877-3b38defe3f36.png)

No issues in 6.1.1.