### PR TITLE
Add filter to deactivate the plugin from the code

### DIFF
--- a/autoptimize.php
+++ b/autoptimize.php
@@ -90,6 +90,10 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
     require AUTOPTIMIZE_PLUGIN_DIR . 'classes/autoptimizeCLI.php';
 }
 
+if ( apply_filters( 'autoptimize_filter_disable_plugin', false ) ) {
+    return;
+}
+
 /**
  * Retrieve the instance of the main plugin class.
  *


### PR DESCRIPTION
This PR adds a new filter (disabled by default) to deactivate the plugin from the code.

Useful when Autoptimize is a dependency of another plugin installed in both standard and headless installations and you want to disable it only in the latter.

Originally discussed in https://wordpress.org/support/topic/filter-to-deactivate-the-plugin/