### PR TITLE
Avoid race condition on disable filter

### DIFF
--- a/autoptimize.php
+++ b/autoptimize.php
@@ -90,11 +90,6 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
     require AUTOPTIMIZE_PLUGIN_DIR . 'classes/autoptimizeCLI.php';
 }
 
-// filter to disable AO both on front- and backend.
-if ( apply_filters( 'autoptimize_filter_disable_plugin', false ) ) {
-    return;
-}
-
 /**
  * Retrieve the instance of the main plugin class.
  *
@@ -110,4 +105,14 @@ function autoptimize() {
     return $plugin;
 }
 
-autoptimize()->run();
+add_action(
+    'init',
+    function() {
+        // filter to disable AO both on front- and backend.
+        if ( ! apply_filters( 'autoptimize_filter_disable_plugin', false ) ) {
+            autoptimize()->run();
+        }
+    },
+    1000,
+    0
+);


### PR DESCRIPTION
The `autoptimize_filter_disable_plugin` filter is applied immediately, during this plugin's load, when other plugins' code may not even have loaded yet. Attaching to that filter in time is completely up to chance. If a plugin does get to attach to the filter, it's unlikely it can decide whether to disable it. [The typical event][0] upon which most plugins initialise themselves, when relevant resources are available, comes much later.

This patch delays initialisation until the appropriate place in the loading sequence.

[0]: https://developer.wordpress.org/reference/hooks/init/