### PR TITLE
Check for error from preg_replace_callback()

### DIFF
--- a/classes/autoptimizeBase.php
+++ b/classes/autoptimizeBase.php
@@ -599,6 +599,15 @@ abstract class autoptimizeBase
                 },
                 $content
             );
+
+            // Check for error (for example, an error can occur if $content is very large).
+            if ( null === $content ) {
+                $error_message = 'Autoptimize: preg_replace_callback() failed';
+                if ( function_exists( 'preg_last_error_msg' ) ) {
+                    $error_message .= ': ' . preg_last_error_msg();
+                }
+                error_log( $error_message );
+            }
         }
 
         return $content;


### PR DESCRIPTION
This is intended to address issue #421 where preg_replace_callback() was failing for pages with large scripts.

This does not actually fix the issue but at least it now will generate a message in the error log.